### PR TITLE
Fix PDF template path in generator

### DIFF
--- a/app/pdf_generator.py
+++ b/app/pdf_generator.py
@@ -1,4 +1,7 @@
 import io
+import os
+
+from flask import current_app
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
 from PyPDF2 import PdfReader, PdfWriter
@@ -28,7 +31,8 @@ def generate_pdf(zajecia, beneficjenci, output_path):
     buffer.seek(0)
 
     # Nałóż na wzór PDF
-    template = PdfReader("static/wzor.pdf")
+    template_path = os.path.join(current_app.root_path, "static", "wzor.pdf")
+    template = PdfReader(template_path)
     output = PdfWriter()
     overlay = PdfReader(buffer)
 


### PR DESCRIPTION
## Summary
- build template path with `current_app.root_path`
- adjust imports in `pdf_generator.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688920c6aa94832a97b46fa7654e918e