### PR TITLE
Remove psycopg2-binary dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ flask
 flask-login
 flask-wtf
 flask-sqlalchemy
-psycopg2-binary
 werkzeug
 reportlab
 PyPDF2


### PR DESCRIPTION
## Summary
- prune unused psycopg2-binary from requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688921a88ff8832aab2a67138b05fa6b