### PR TITLE
Improve README instructions for SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@ A small Flask application that lets specialists register sessions with beneficia
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Export a `SECRET_KEY` environment variable. In development mode (`FLASK_ENV=development`) the app will use a fallback value if it is not set, but in other environments it must be provided.
-3. Start the application:
+2. Export a `SECRET_KEY` environment variable when deploying to production. If it
+   is missing and `FLASK_ENV=development`, a fallback key will be used.
+3. Run the application in development mode without setting `SECRET_KEY`:
+   ```bash
+   export FLASK_ENV=development
+   flask --app run.py run
+   ```
+   In production you **must** define `SECRET_KEY` before starting the
+   application.
+4. Start the application normally:
    ```bash
    flask --app run.py run
    ```


### PR DESCRIPTION
## Summary
- clarify how to run the app in development without defining `SECRET_KEY`
- mention that `SECRET_KEY` must be set when running in production

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889377ac314832abf2fe0e354e9e839