### PR TITLE
Add .env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and set your values
+SECRET_KEY=replace-me
+# Optional: set FLASK_ENV to configure the environment
+FLASK_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ celerybeat-schedule
 # dotenv
 .env
 .env.*
+!.env.example
 
 # virtualenv
 .venv/

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ A small Flask application that lets specialists register sessions with beneficia
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Export a `SECRET_KEY` environment variable when deploying to production. If it
-   is missing and `FLASK_ENV=development`, a fallback key will be used.
-3. Run the application in development mode without setting `SECRET_KEY`:
+2. Copy `.env.example` to `.env` and set `SECRET_KEY` to a secure value.
+   The `flask` command will load variables from this file automatically.
+3. (Optional) Run in development mode:
    ```bash
    export FLASK_ENV=development
    flask --app run.py run
    ```
-   In production you **must** define `SECRET_KEY` before starting the
-   application.
+   In production you **must** provide a real `SECRET_KEY` in `.env`.
 4. Start the application normally:
    ```bash
    flask --app run.py run
@@ -30,7 +29,7 @@ You can build and run the project in a container:
 
 ```bash
 docker build -t konsultacje .
-docker run -e SECRET_KEY=your-secret -p 8080:5000 konsultacje
+docker run --env-file .env -p 8080:5000 konsultacje
 ```
 
 Alternatively run `docker-compose up` to use the provided compose file which exposes the app on port `8080`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
+from dotenv import load_dotenv
 
 db = SQLAlchemy()
 login_manager = LoginManager()
@@ -9,6 +10,8 @@ login_manager.login_view = 'login'
 
 
 def create_app():
+    env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+    load_dotenv(env_path)
     app = Flask(__name__)
     # Flask 3 removed the `app.env` attribute. Use the configuration value
     # instead which is populated from the `FLASK_ENV` environment variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-sqlalchemy
 werkzeug
 reportlab
 PyPDF2
+python-dotenv


### PR DESCRIPTION
## Summary
- ignore `.env` but track `.env.example`
- load `.env` automatically when creating the Flask app
- document usage of `.env` and include example file
- support `.env` for Docker usage
- add `python-dotenv` dependency

## Testing
- `pip install -q -r requirements.txt`
- `python -m compileall -q app run.py`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_688939a9433c832aa52d6a82a44d9e0a