### PR TITLE
Add admin account setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 # Copy this file to .env and set your values
 SECRET_KEY=replace-me
+# Credentials for the initial admin account
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me
+ADMIN_EMAIL=admin@example.com
 # Optional: set FLASK_ENV to configure the environment
 FLASK_ENV=development

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A small Flask application that lets specialists register sessions with beneficia
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Copy `.env.example` to `.env` and set `SECRET_KEY` to a secure value.
-   The `flask` command will load variables from this file automatically.
+2. Copy `.env.example` to `.env` and set values for `SECRET_KEY`,
+   `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
+   The `flask` command will load variables from this file automatically
+   and an admin user will be created if it does not exist.
 3. (Optional) Run in development mode:
    ```bash
    export FLASK_ENV=development

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,9 @@ def create_app():
     # instead which is populated from the `FLASK_ENV` environment variable.
     env = app.config.get("ENV")
     secret_key = os.environ.get("SECRET_KEY")
+    admin_username = os.environ.get("ADMIN_USERNAME")
+    admin_password = os.environ.get("ADMIN_PASSWORD")
+    admin_email = os.environ.get("ADMIN_EMAIL")
     if secret_key:
         app.config["SECRET_KEY"] = secret_key
     elif env == "development":
@@ -46,5 +49,14 @@ def create_app():
     with app.app_context():
         from . import routes, models  # noqa: F401
         db.create_all()
+
+        if admin_username and admin_password:
+            from .models import User
+            admin = User.query.filter_by(username=admin_username).first()
+            if not admin:
+                admin = User(username=admin_username, email=admin_email)
+                admin.set_password(admin_password)
+                db.session.add(admin)
+                db.session.commit()
 
     return app


### PR DESCRIPTION
## Summary
- extend `.env.example` with admin credentials
- create an admin user during app initialization when credentials are provided
- document the new environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688944b2db58832a9e0406f6829159dd