### PR TITLE
Configure Flask-Mail via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ ADMIN_PASSWORD=change-me
 ADMIN_EMAIL=admin@example.com
 # Optional: set FLASK_ENV to configure the environment
 FLASK_ENV=development
+# Mail server settings for password reset emails
+MAIL_SERVER=localhost
+MAIL_PORT=25
+MAIL_USERNAME=
+MAIL_PASSWORD=
+# Optional TLS/SSL flags
+MAIL_USE_TLS=false
+MAIL_USE_SSL=false

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A small Flask application that lets specialists register sessions with beneficia
    ```
 2. Copy `.env.example` to `.env` and set values for `SECRET_KEY`,
    `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
+   Configure email delivery with `MAIL_SERVER`, `MAIL_PORT`,
+   `MAIL_USERNAME`, `MAIL_PASSWORD`, and optionally `MAIL_USE_TLS`
+   or `MAIL_USE_SSL` for encrypted connections.
    The `flask` command will load variables from this file automatically
    and an admin user will be created if it does not exist.
 3. (Optional) Run in development mode:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,13 +45,21 @@ def create_app():
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    app.config["MAIL_SERVER"] = os.environ.get("MAIL_SERVER", "localhost")
-    app.config["MAIL_PORT"] = int(os.environ.get("MAIL_PORT", 25))
-    app.config["MAIL_USERNAME"] = os.environ.get("MAIL_USERNAME")
-    app.config["MAIL_PASSWORD"] = os.environ.get("MAIL_PASSWORD")
-    app.config["MAIL_USE_TLS"] = os.environ.get("MAIL_USE_TLS", "false").lower() == "true"
-    app.config["MAIL_USE_SSL"] = os.environ.get("MAIL_USE_SSL", "false").lower() == "true"
-    app.config["MAIL_DEFAULT_SENDER"] = os.environ.get("MAIL_DEFAULT_SENDER", admin_email)
+    mail_server = os.environ.get("MAIL_SERVER", "localhost")
+    mail_port = int(os.environ.get("MAIL_PORT", 25))
+    mail_username = os.environ.get("MAIL_USERNAME")
+    mail_password = os.environ.get("MAIL_PASSWORD")
+    mail_use_tls = os.environ.get("MAIL_USE_TLS", "false").lower() == "true"
+    mail_use_ssl = os.environ.get("MAIL_USE_SSL", "false").lower() == "true"
+    app.config.update(
+        MAIL_SERVER=mail_server,
+        MAIL_PORT=mail_port,
+        MAIL_USERNAME=mail_username,
+        MAIL_PASSWORD=mail_password,
+        MAIL_USE_TLS=mail_use_tls,
+        MAIL_USE_SSL=mail_use_ssl,
+        MAIL_DEFAULT_SENDER=os.environ.get("MAIL_DEFAULT_SENDER", admin_email),
+    )
 
     db.init_app(app)
     login_manager.init_app(app)


### PR DESCRIPTION
## Summary
- add mail environment variables to `.env.example`
- load mail config from environment in `create_app`
- document mail variables in README

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68894766e6f4832a8da0a34f721261ea