### PR TITLE
Display flashed messages

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,16 @@
 </head>
 <body class="bg-light text-dark">
   <div class="container mt-5">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        {% for message in messages %}
+          <div class="alert alert-info alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
     {% block content %}{% endblock %}
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add bootstrap alert display for flashed messages in base template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68894c4b8e0c832a90092676c5c65c01