### PR TITLE
Fix login redirect safety check

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -31,6 +31,7 @@ from .forms import (
 from .models import Beneficjent, User, Zajecia
 from . import mail
 from .pdf_generator import generate_pdf
+from urllib.parse import urlparse
 
 
 class LoginForm(FlaskForm):
@@ -42,13 +43,15 @@ class LoginForm(FlaskForm):
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():
-    next = request.args.get('next')
+    next_url = request.args.get('next')
     form = LoginForm()
     if form.validate_on_submit():
         user = User.query.filter_by(username=form.username.data).first()
         if user and user.check_password(form.password.data):
             login_user(user, remember=form.remember_me.data)
-            return redirect(next or url_for('dashboard'))
+            if not next_url or urlparse(next_url).netloc != "":
+                next_url = url_for('dashboard')
+            return redirect(next_url)
         flash('Nieprawidłowe dane logowania.')
     return render_template('login.html', form=form)
 


### PR DESCRIPTION
## Summary
- avoid shadowing built-in `next`
- validate login redirect target using `urlparse`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894ccaa764832a918e4259ed89c8bb