### PR TITLE
Add navbar and clean up logout button

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,6 +7,31 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 </head>
 <body class="bg-light text-dark">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Konsultacje</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>
+          </li>
+        </ul>
+        {% if current_user.is_authenticated %}
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('logout') }}">Wyloguj</a>
+          </li>
+        </ul>
+        {% endif %}
+      </div>
+    </div>
+  </nav>
   <div class="container mt-5">
     {% with messages = get_flashed_messages() %}
       {% if messages %}
@@ -20,5 +45,6 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -3,5 +3,4 @@
 {% block content %}
 <h2>Witaj, {{ name }}!</h2>
 <p>To jest twój panel prowadzącego. Wkrótce dodasz tutaj beneficjentów i zajęcia.</p>
-<a href="{{ url_for('logout') }}" class="btn btn-secondary">Wyloguj</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap navbar linking to dashboard, zajęcia form and logout
- remove old logout button from dashboard template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894e80c2c8832aa1e46cc84764772b