### PR TITLE
Add Beneficjent CRUD and session list

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -51,3 +51,9 @@ class PasswordResetForm(FlaskForm):
     )
     submit = SubmitField('Zresetuj hasło')
 
+
+class BeneficjentForm(FlaskForm):
+    imie = StringField('Imię i nazwisko', validators=[DataRequired()])
+    wojewodztwo = StringField('Województwo', validators=[DataRequired()])
+    submit = SubmitField('Zapisz')
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,12 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('lista_zajec') }}">Lista zajęć</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('lista_beneficjentow') }}">Beneficjenci</a>
+          </li>
         </ul>
         {% if current_user.is_authenticated %}
         <ul class="navbar-nav">

--- a/app/templates/beneficjenci_list.html
+++ b/app/templates/beneficjenci_list.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Beneficjenci{% endblock %}
+{% block content %}
+<h2>Beneficjenci</h2>
+<a href="{{ url_for('nowy_beneficjent') }}" class="btn btn-success mb-3">Dodaj beneficjenta</a>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Imię i nazwisko</th>
+      <th>Województwo</th>
+      <th>Akcje</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for b in beneficjenci %}
+    <tr>
+      <td>{{ b.imie }}</td>
+      <td>{{ b.wojewodztwo }}</td>
+      <td>
+        <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+        <form method="post" action="{{ url_for('usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
+        </form>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">Brak beneficjentów.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/beneficjent_form.html
+++ b/app/templates/beneficjent_form.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<h2>{{ title }}</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.imie.label(class="form-label") }}
+    {{ form.imie(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.wojewodztwo.label(class="form-label") }}
+    {{ form.wojewodztwo(class="form-control") }}
+  </div>
+  <button type="submit" class="btn btn-success">{{ form.submit.label.text }}</button>
+</form>
+{% endblock %}

--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Lista zajęć{% endblock %}
+{% block content %}
+<h2>Lista zajęć</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Data</th>
+      <th>Godziny</th>
+      <th>Specjalista</th>
+      <th>PDF</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for zaj in zajecia_list %}
+    <tr>
+      <td>{{ zaj.data.strftime('%d.%m.%Y') }}</td>
+      <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
+      <td>{{ zaj.specjalista }}</td>
+      <td>
+        <a href="{{ url_for('pobierz_pdf', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz PDF</a>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">Brak zajęć.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `BeneficjentForm`
- implement session list and Beneficjent CRUD routes
- update navigation
- add templates for Beneficjent management and session list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688950be8bcc832a840dccb91a069323