### PR TITLE
Add CSRF protection for delete form

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,12 +3,14 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_mail import Mail
+from flask_wtf import CSRFProtect
 from dotenv import load_dotenv
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 login_manager.login_view = 'login'
 mail = Mail()
+csrf = CSRFProtect()
 
 
 def create_app():
@@ -64,6 +66,7 @@ def create_app():
     db.init_app(app)
     login_manager.init_app(app)
     mail.init_app(app)
+    csrf.init_app(app)
 
     with app.app_context():
         from . import routes, models  # noqa: F401

--- a/app/forms.py
+++ b/app/forms.py
@@ -57,3 +57,7 @@ class BeneficjentForm(FlaskForm):
     wojewodztwo = StringField('Województwo', validators=[DataRequired()])
     submit = SubmitField('Zapisz')
 
+
+class DeleteForm(FlaskForm):
+    submit = SubmitField('Usuń')
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -29,6 +29,7 @@ from .forms import (
     PasswordResetRequestForm,
     PasswordResetForm,
     BeneficjentForm,
+    DeleteForm,
 )
 from .models import Beneficjent, User, Zajecia
 from . import mail
@@ -202,7 +203,12 @@ def lista_zajec():
 @login_required
 def lista_beneficjentow():
     beneficjenci = Beneficjent.query.filter_by(user_id=current_user.id).all()
-    return render_template('beneficjenci_list.html', beneficjenci=beneficjenci)
+    delete_form = DeleteForm()
+    return render_template(
+        'beneficjenci_list.html',
+        beneficjenci=beneficjenci,
+        delete_form=delete_form,
+    )
 
 
 @app.route('/beneficjenci/nowy', methods=['GET', 'POST'])
@@ -246,11 +252,13 @@ def edytuj_beneficjenta(beneficjent_id):
 @app.route('/beneficjenci/<int:beneficjent_id>/usun', methods=['POST'])
 @login_required
 def usun_beneficjenta(beneficjent_id):
-    benef = Beneficjent.query.get_or_404(beneficjent_id)
-    if benef.user_id != current_user.id:
-        flash('Brak dostępu do tego beneficjenta.')
-        return redirect(url_for('lista_beneficjentow'))
-    db.session.delete(benef)
-    db.session.commit()
-    flash('Beneficjent usunięty.')
+    form = DeleteForm()
+    if form.validate_on_submit():
+        benef = Beneficjent.query.get_or_404(beneficjent_id)
+        if benef.user_id != current_user.id:
+            flash('Brak dostępu do tego beneficjenta.')
+            return redirect(url_for('lista_beneficjentow'))
+        db.session.delete(benef)
+        db.session.commit()
+        flash('Beneficjent usunięty.')
     return redirect(url_for('lista_beneficjentow'))

--- a/app/templates/beneficjenci_list.html
+++ b/app/templates/beneficjenci_list.html
@@ -19,6 +19,7 @@
       <td>
         <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
         <form method="post" action="{{ url_for('usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
+          {{ delete_form.csrf_token }}
           <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
         </form>
       </td>


### PR DESCRIPTION
## Summary
- enable global CSRF protection
- create `DeleteForm` and use it when deleting beneficiaries
- render CSRF token in `beneficjenci_list.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688959ccd3e4832a8a8b911c0316a0b6