### PR TITLE
Enforce SECRET_KEY in all envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A small Flask application that lets specialists register sessions with beneficia
    ```
 2. Copy `.env.example` to `.env` and set values for `SECRET_KEY`,
    `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
+   A secure `SECRET_KEY` is required in **all** environments. You can
+   generate one with:
+
+   ```bash
+   python -c "import secrets; print(secrets.token_hex(32))"
+   ```
+
    Configure email delivery with `MAIL_SERVER`, `MAIL_PORT`,
    `MAIL_USERNAME`, `MAIL_PASSWORD`, and optionally `MAIL_USE_TLS`
    or `MAIL_USE_SSL` for encrypted connections.
@@ -22,7 +29,7 @@ A small Flask application that lets specialists register sessions with beneficia
    export FLASK_ENV=development
    flask --app run.py run
    ```
-   In production you **must** provide a real `SECRET_KEY` in `.env`.
+   The application will fail to start if `SECRET_KEY` is missing.
 4. Start the application normally:
    ```bash
    flask --app run.py run

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,8 +24,7 @@ def app(monkeypatch):
     import app as app_package
     if hasattr(app_package, 'routes'):
         delattr(app_package, 'routes')
-    app = create_app()
-    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, MAIL_SUPPRESS_SEND=True)
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False, "MAIL_SUPPRESS_SEND": True})
     return app
 
 
@@ -40,8 +39,7 @@ def test_admin_created_from_env(monkeypatch):
     monkeypatch.setenv('ADMIN_USERNAME', 'admin')
     monkeypatch.setenv('ADMIN_PASSWORD', 'adminpass')
     monkeypatch.setenv('ADMIN_EMAIL', 'admin@example.com')
-    app = create_app()
-    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
     with app.app_context():
         admin = User.query.filter_by(username='admin').first()
         assert admin is not None


### PR DESCRIPTION
## Summary
- require SECRET_KEY for every environment
- allow an insecure key only when testing
- document generating a secure key in README

## Testing
- `pip install -r requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895bb70710832a90f8d0abe237f8c3