### PR TITLE
Migrate to pypdf and modern SQLAlchemy get()

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -33,12 +33,12 @@ class User(UserMixin, db.Model):
             data = s.loads(token, max_age=expires_sec)
         except Exception:
             return None
-        return User.query.get(data.get('user_id'))
+        return db.session.get(User, data.get('user_id'))
 
 
 @login_manager.user_loader
 def load_user(user_id):
-    return User.query.get(int(user_id))
+    return db.session.get(User, int(user_id))
 
 # Additional application models
 

--- a/app/pdf_generator.py
+++ b/app/pdf_generator.py
@@ -6,7 +6,7 @@ import os
 from flask import current_app
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
-from PyPDF2 import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter
 
 
 def generate_pdf(zajecia, beneficjenci, output_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask-wtf
 flask-sqlalchemy
 werkzeug
 reportlab
-PyPDF2
+pypdf
 python-dotenv
 Flask-Mail
 email_validator

--- a/tests/test_beneficjent_pdf.py
+++ b/tests/test_beneficjent_pdf.py
@@ -42,7 +42,7 @@ def test_beneficjent_crud(app, client):
     )
     assert 'Beneficjent zaktualizowany' in response.get_data(as_text=True)
     with app.app_context():
-        benef = Beneficjent.query.get(benef_id)
+        benef = db.session.get(Beneficjent, benef_id)
         assert benef.imie == 'Jan Nowak'
         assert benef.wojewodztwo == 'Slaskie'
 
@@ -54,7 +54,7 @@ def test_beneficjent_crud(app, client):
     )
     assert 'Beneficjent usunięty' in response.get_data(as_text=True)
     with app.app_context():
-        assert Beneficjent.query.get(benef_id) is None
+        assert db.session.get(Beneficjent, benef_id) is None
 
 
 def test_create_session(app, client):


### PR DESCRIPTION
## Summary
- replace legacy `Query.get()` usages in `models.py`
- switch PDF generator to `pypdf`
- update dependencies
- update tests for `db.session.get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e5dcee54832aa28ffabbb4b02443