### PR TITLE
Check duplicate email on registration

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -66,6 +66,11 @@ def login():
 def register():
     form = RegisterForm()
     if form.validate_on_submit():
+        # prevent duplicate accounts with the same email address
+        if User.query.filter_by(email=form.email.data).first():
+            flash('Użytkownik z tym adresem email już istnieje.')
+            return render_template('register.html', form=form)
+
         user = User(username=form.username.data, email=form.email.data)
         user.set_password(form.password.data)
         db.session.add(user)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,6 +71,34 @@ def test_register_and_login_remember_me(client, app):
     assert client.get_cookie('remember_token') is not None
 
 
+def test_register_duplicate_email(client, app):
+    """Registering with an existing email should show an error message."""
+    # first registration
+    client.post(
+        '/register',
+        data={
+            'username': 'user1',
+            'email': 'duplicate@example.com',
+            'password': 'secret',
+            'confirm': 'secret',
+        },
+        follow_redirects=True,
+    )
+
+    response = client.post(
+        '/register',
+        data={
+            'username': 'user2',
+            'email': 'duplicate@example.com',
+            'password': 'secret',
+            'confirm': 'secret',
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert 'Użytkownik z tym adresem email już istnieje.' in response.get_data(as_text=True)
+
+
 def test_password_reset_flow(monkeypatch, app):
     with app.app_context():
         user = User(username='bob', email='bob@example.com')


### PR DESCRIPTION
## Summary
- avoid duplicate accounts on registration by verifying email
- inform the user when the email already exists
- test registering with an existing email address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9115a15c832abea72dad18b1c557