### PR TITLE
Delete generated PDFs after download

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,7 @@ from flask import (
     request,
     send_file,
     url_for,
+    after_this_request,
 )
 from flask_login import (
     current_user,
@@ -157,6 +158,14 @@ def pobierz_pdf(zajecia_id):
     output_path = os.path.join(output_dir, f"zajecia_{zajecia.id}.pdf")
 
     generate_pdf(zajecia, beneficjenci, output_path)
+
+    @after_this_request
+    def remove_file(response):
+        try:
+            os.remove(output_path)
+        except OSError:
+            current_app.logger.warning("Failed to remove generated PDF %s", output_path)
+        return response
 
     return send_file(output_path, as_attachment=True)
 

--- a/tests/test_beneficjent_pdf.py
+++ b/tests/test_beneficjent_pdf.py
@@ -103,7 +103,5 @@ def test_pdf_generation(app, client):
     assert response.headers.get('Content-Disposition', '').startswith('attachment')
 
     pdf_path = os.path.join(app.root_path, 'static', 'pdf', f'zajecia_{z_id}.pdf')
-    assert os.path.exists(pdf_path)
-
-    # clean up generated file
-    os.remove(pdf_path)
+    # the generated PDF should be removed after the response is sent
+    assert not os.path.exists(pdf_path)


### PR DESCRIPTION
## Summary
- clean up generated PDFs in `pobierz_pdf`
- check that the PDF file is removed in the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa8bbc2f8832aa48b7690dde0cf1a