### PR TITLE
Improve password inputs

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Konsultacje{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 </head>
 <body class="bg-light text-dark">
   <header class="bg-white border-bottom py-2 mb-3">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -12,10 +12,11 @@
   </div>
   <div class="mb-3">
     {{ form.password.label(class="form-label") }}
-    {{ form.password(class="form-control", type="password", id=form.password.id, **{'aria-label': 'Hasło'}) }}
-    <div class="form-check mt-1">
-      <input class="form-check-input" type="checkbox" id="show-password">
-      <label class="form-check-label" for="show-password">Pokaż hasło</label>
+    <div class="input-group">
+      {{ form.password(class="form-control", type="password", id=form.password.id, **{'aria-label': 'Hasło'}) }}
+      <span class="input-group-text">
+        <i class="bi bi-eye-slash toggle-password" data-target="{{ form.password.id }}" role="button"></i>
+      </span>
     </div>
   </div>
   <div class="form-check mb-3">
@@ -31,9 +32,19 @@
 </p>
 <p class="mt-2"><a href="{{ url_for('reset_password_request') }}">Zapomniałeś hasła?</a></p>
 <script>
-  document.getElementById('show-password').addEventListener('change', function() {
-    const pw = document.getElementById('{{ form.password.id }}');
-    pw.type = this.checked ? 'text' : 'password';
+  document.querySelectorAll('.toggle-password').forEach(function(icon) {
+    icon.addEventListener('click', function() {
+      const target = document.getElementById(this.dataset.target);
+      if (target.type === 'password') {
+        target.type = 'text';
+        this.classList.remove('bi-eye-slash');
+        this.classList.add('bi-eye');
+      } else {
+        target.type = 'password';
+        this.classList.add('bi-eye-slash');
+        this.classList.remove('bi-eye');
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -16,15 +16,41 @@
   </div>
   <div class="mb-3">
     {{ form.password.label(class="form-label") }}
-    {{ form.password(class="form-control", type="password", **{'aria-label': 'Hasło'}) }}
+    <div class="input-group">
+      {{ form.password(class="form-control", type="password", id=form.password.id, **{'aria-label': 'Hasło'}) }}
+      <span class="input-group-text">
+        <i class="bi bi-eye-slash toggle-password" data-target="{{ form.password.id }}" role="button"></i>
+      </span>
+    </div>
   </div>
   <div class="mb-3">
     {{ form.confirm.label(class="form-label") }}
-    {{ form.confirm(class="form-control", type="password", **{'aria-label': 'Potwierdź hasło'}) }}
+    <div class="input-group">
+      {{ form.confirm(class="form-control", type="password", id=form.confirm.id, **{'aria-label': 'Potwierdź hasło'}) }}
+      <span class="input-group-text">
+        <i class="bi bi-eye-slash toggle-password" data-target="{{ form.confirm.id }}" role="button"></i>
+      </span>
+    </div>
   </div>
   <button type="submit" class="btn btn-success">{{ form.submit.label.text }}</button>
     </form>
   </div>
 </div>
+<script>
+  document.querySelectorAll('.toggle-password').forEach(function(icon) {
+    icon.addEventListener('click', function() {
+      const target = document.getElementById(this.dataset.target);
+      if (target.type === 'password') {
+        target.type = 'text';
+        this.classList.remove('bi-eye-slash');
+        this.classList.add('bi-eye');
+      } else {
+        target.type = 'password';
+        this.classList.add('bi-eye-slash');
+        this.classList.remove('bi-eye');
+      }
+    });
+  });
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show/hide password with Bootstrap icons
- add JS toggle to login and register forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688beaf9038c832aa21ac2b1c4caa57e