### PR TITLE
Require SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A small Flask application that lets specialists register sessions with beneficia
    ```
 2. Copy `.env.example` to `.env` and set values for `SECRET_KEY`,
    `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
-   A secure `SECRET_KEY` is required in **all** environments. You can
-   generate one with:
+   A secure `SECRET_KEY` is required in **all** environments and there is
+   no automatic fallback. You can generate one with:
 
    ```bash
    python -c "import secrets; print(secrets.token_hex(32))"
@@ -74,4 +74,4 @@ pip install -r requirements.txt pytest
 pytest
 ```
 
-This will create a temporary SQLite database in the `instance/` folder while the tests run.
+This will create a temporary SQLite database in the `instance/` folder while the tests run. Each test passes a `SECRET_KEY` directly to `create_app`. If you add more tests, ensure `SECRET_KEY` is supplied via the configuration or environment.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,21 +37,21 @@ def create_app(test_config=None):
     load_dotenv(env_path)
     app = Flask(__name__)
     # Flask loads configuration from environment variables such as `FLASK_ENV`.
-    secret_key = os.environ.get("SECRET_KEY")
+    secret_key = None
+    if test_config is not None:
+        secret_key = test_config.get("SECRET_KEY")
+
+    if not secret_key:
+        secret_key = os.environ.get("SECRET_KEY")
+
     admin_username = os.environ.get("ADMIN_USERNAME")
     admin_password = os.environ.get("ADMIN_PASSWORD")
     admin_email = os.environ.get("ADMIN_EMAIL")
 
     if not secret_key:
-        if test_config and test_config.get("TESTING"):
-            app.logger.warning(
-                "SECRET_KEY not set, using insecure test key."
-            )
-            secret_key = "test-secret-key"
-        else:
-            raise RuntimeError(
-                "SECRET_KEY environment variable is not set."
-            )
+        raise RuntimeError(
+            "SECRET_KEY must be provided via environment or configuration."
+        )
 
     app.config["SECRET_KEY"] = secret_key
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,15 +10,13 @@ def app(monkeypatch):
     if os.path.exists(db_path):
         os.remove(db_path)
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
-    monkeypatch.setenv('SECRET_KEY', 'test-secret')
-
     # Reload routes so they register on a fresh app instance
     sys.modules.pop('app.routes', None)
     import app as app_package  # noqa: F401
     if hasattr(app_package, 'routes'):
         delattr(app_package, 'routes')
 
-    app = create_app({'TESTING': True, 'WTF_CSRF_ENABLED': False, 'MAIL_SUPPRESS_SEND': True})
+    app = create_app({'TESTING': True, 'WTF_CSRF_ENABLED': False, 'MAIL_SUPPRESS_SEND': True, 'SECRET_KEY': 'test-secret'})
     return app
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,14 +17,13 @@ def setup_database():
 @pytest.fixture
 def app(monkeypatch):
     setup_database()
-    monkeypatch.setenv('SECRET_KEY', 'test-secret')
     # Reload routes so they register on the fresh app instance
     import sys
     sys.modules.pop('app.routes', None)
     import app as app_package
     if hasattr(app_package, 'routes'):
         delattr(app_package, 'routes')
-    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False, "MAIL_SUPPRESS_SEND": True})
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False, "MAIL_SUPPRESS_SEND": True, "SECRET_KEY": "test-secret"})
     return app
 
 
@@ -35,11 +34,10 @@ def client(app):
 
 def test_admin_created_from_env(monkeypatch):
     setup_database()
-    monkeypatch.setenv('SECRET_KEY', 'test-secret')
     monkeypatch.setenv('ADMIN_USERNAME', 'admin')
     monkeypatch.setenv('ADMIN_PASSWORD', 'adminpass')
     monkeypatch.setenv('ADMIN_EMAIL', 'admin@example.com')
-    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False, "SECRET_KEY": "test-secret"})
     with app.app_context():
         admin = User.query.filter_by(full_name='admin').first()
         assert admin is not None


### PR DESCRIPTION
## Summary
- make SECRET_KEY mandatory in `create_app`
- pass SECRET_KEY in tests via config
- document the new requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c064a49e8832aafb7e376e8188e8b