### PR TITLE
Center main containers with Bootstrap

### DIFF
--- a/app/templates/admin/beneficjenci_list.html
+++ b/app/templates/admin/beneficjenci_list.html
@@ -2,7 +2,7 @@
 {% block title %}Wszyscy beneficjenci{% endblock %}
 {% block content %}
 <h2>Wszyscy beneficjenci</h2>
-<table class="table">
+<table class="table mx-auto text-start">
   <thead>
     <tr>
       <th>Imię i nazwisko</th>

--- a/app/templates/admin/instructors_list.html
+++ b/app/templates/admin/instructors_list.html
@@ -2,7 +2,7 @@
 {% block title %}Instruktorzy{% endblock %}
 {% block content %}
 <h2>Instruktorzy</h2>
-<table class="table">
+<table class="table mx-auto text-start">
   <thead>
     <tr>
       <th>Imię i nazwisko</th>

--- a/app/templates/admin/zajecia_list.html
+++ b/app/templates/admin/zajecia_list.html
@@ -2,7 +2,7 @@
 {% block title %}Wszystkie zajęcia{% endblock %}
 {% block content %}
 <h2>Wszystkie zajęcia</h2>
-<table class="table">
+<table class="table mx-auto text-start">
   <thead>
     <tr>
       <th>Data</th>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -99,7 +99,7 @@
     </div>
   </div>
   {% endif %}
-    <div class="container mt-5">
+    <div class="container mt-5 text-center">
     {% with messages = get_flashed_messages() %}
       {% if messages %}
         {% for message in messages %}

--- a/app/templates/beneficjenci_list.html
+++ b/app/templates/beneficjenci_list.html
@@ -9,7 +9,7 @@
   </div>
 </form>
 <a href="{{ url_for('nowy_beneficjent') }}" class="btn btn-success mb-3">Dodaj beneficjenta</a>
-<table class="table">
+<table class="table mx-auto text-start">
   <thead>
     <tr>
       <th>Imię i nazwisko</th>

--- a/app/templates/beneficjent_form.html
+++ b/app/templates/beneficjent_form.html
@@ -2,7 +2,8 @@
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
 <h2>{{ title }}</h2>
-<form method="post">
+<div class="d-flex justify-content-center">
+<form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.imie.label(class="form-label") }}
@@ -14,4 +15,5 @@
   </div>
   <button type="submit" class="btn btn-success">{{ form.submit.label.text }}</button>
 </form>
+</div>
 {% endblock %}

--- a/app/templates/instructor_form.html
+++ b/app/templates/instructor_form.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Edytuj instruktora{% endblock %}
 {% block content %}
-<form method="post">
+<div class="d-flex justify-content-center">
+<form method="post" class="text-start">
   {{ form.csrf_token }}
   <div class="mb-3">
     {{ form.full_name.label }}
@@ -13,4 +14,5 @@
   </div>
   <button type="submit" class="btn btn-primary">Zapisz</button>
 </form>
+</div>
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -2,9 +2,9 @@
 {% block title %}Logowanie{% endblock %}
 {% block content %}
 <h2>Logowanie</h2>
-<div class="row justify-content-center">
+<div class="row justify-content-center text-center">
   <div class="col-md-6">
-    <form method="post">
+    <form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.full_name.label(class="form-label") }}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -2,9 +2,9 @@
 {% block title %}Rejestracja{% endblock %}
 {% block content %}
 <h2>Rejestracja</h2>
-<div class="row justify-content-center">
+<div class="row justify-content-center text-center">
   <div class="col-md-6">
-    <form method="post">
+    <form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.full_name.label(class="form-label") }}

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -2,9 +2,9 @@
 {% block title %}Nowe hasło{% endblock %}
 {% block content %}
 <h2>Ustaw nowe hasło</h2>
-<div class="row justify-content-center">
+<div class="row justify-content-center text-center">
   <div class="col-md-6">
-    <form method="post">
+    <form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.password.label(class="form-label") }}

--- a/app/templates/reset_password_request.html
+++ b/app/templates/reset_password_request.html
@@ -2,9 +2,9 @@
 {% block title %}Resetowanie hasła{% endblock %}
 {% block content %}
 <h2>Resetowanie hasła</h2>
-<div class="row justify-content-center">
+<div class="row justify-content-center text-center">
   <div class="col-md-6">
-    <form method="post">
+    <form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.email.label(class="form-label") }}

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -2,7 +2,8 @@
 {% block title %}Nowe zajęcia{% endblock %}
 {% block content %}
 <h2>Nowe zajęcia</h2>
-<form method="post">
+<div class="d-flex justify-content-center">
+<form method="post" class="text-start">
   {{ form.hidden_tag() }}
   <div class="mb-3">
     {{ form.data.label(class="form-label") }}
@@ -27,4 +28,5 @@
   </div>
   <button type="submit" class="btn btn-success">{{ form.submit.label.text }}</button>
 </form>
+</div>
 {% endblock %}

--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -8,7 +8,7 @@
     <button class="btn btn-primary" type="submit">Szukaj</button>
   </div>
 </form>
-<table class="table">
+<table class="table mx-auto text-start">
   <thead>
     <tr>
       <th>Data</th>


### PR DESCRIPTION
## Summary
- center the main container via Bootstrap
- adjust form templates to keep left-aligned inputs
- center list tables without affecting cell alignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c970a57a8832a92969fe53946a055