### PR TITLE
Remove dashboard view

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -77,7 +77,7 @@ def login():
         if user and user.check_password(form.password.data):
             login_user(user, remember=form.remember_me.data)
             if not next_url or urlparse(next_url).netloc != "":
-                next_url = url_for('dashboard')
+                next_url = url_for('nowe_zajecia')
             return redirect(next_url)
         flash('Nieprawidłowe dane logowania.')
     return render_template('login.html', form=form)
@@ -124,9 +124,9 @@ def logout():
 
 @app.route('/')
 @login_required
-def dashboard():
-    """Display the dashboard for the logged in user."""
-    return render_template('dashboard.html', name=current_user.full_name)
+def index():
+    """Redirect authenticated users to the new session form."""
+    return redirect(url_for('nowe_zajecia'))
 
 
 @app.route('/zajecia/nowe', methods=['GET', 'POST'])
@@ -166,7 +166,7 @@ def nowe_zajecia():
         db.session.add(zajecia)
         db.session.commit()
         flash('Zajęcia zapisane.')
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('index'))
 
     return render_template('zajecia_form.html', form=form)
 
@@ -178,7 +178,7 @@ def pobierz_pdf(zajecia_id):
     zajecia = Zajecia.query.get_or_404(zajecia_id)
     if zajecia.user_id != current_user.id:
         flash("Brak dostępu do tych zajęć.")
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('index'))
 
     beneficjenci = zajecia.beneficjenci
     output_dir = os.path.join(current_app.root_path, "static", "pdf")
@@ -205,7 +205,7 @@ def pobierz_pdf(zajecia_id):
 def reset_password_request():
     """Send a password reset link to the provided email address."""
     if current_user.is_authenticated:
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('index'))
     form = PasswordResetRequestForm()
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
@@ -231,7 +231,7 @@ def reset_password_request():
 def reset_password(token):
     """Allow the user to set a new password using a token."""
     if current_user.is_authenticated:
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('index'))
     user = User.verify_reset_token(token)
     if not user:
         flash('Link resetujący jest nieważny lub wygasł.')

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,14 +17,14 @@
   {% if current_user.is_authenticated %}
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
-      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Konsultacje</a>
+      <a class="navbar-brand" href="{{ url_for('index') }}">Konsultacje</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="d-none d-lg-flex flex-grow-1 justify-content-between" id="navbarNav">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0 justify-content-center">
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+            <a class="nav-link" href="{{ url_for('index') }}">Dashboard</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>
@@ -67,7 +67,7 @@
     <div class="offcanvas-body">
       <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+          <a class="nav-link" href="{{ url_for('index') }}">Dashboard</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -92,7 +92,7 @@ def test_register_and_login_remember_me(client, app):
         'password': 'password',
         'remember_me': 'y',
     }, follow_redirects=True)
-    assert b'Witaj' in response.data
+    assert b'Nowe zaj\xc4\x99cia' in response.data
     assert client.get_cookie('remember_token') is not None
 
 
@@ -168,4 +168,4 @@ def test_password_reset_flow(monkeypatch, app):
         data={'full_name': 'bob', 'password': 'newpass'},
         follow_redirects=True,
     )
-    assert b'Witaj' in response.data
+    assert b'Nowe zaj\xc4\x99cia' in response.data


### PR DESCRIPTION
## Summary
- drop the old dashboard endpoint
- redirect the root route to the new session form
- update default login redirect and navbar links
- adjust tests to expect the new landing page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c982afed0832a813672ce19a05550