### PR TITLE
Use select field for session beneficiaries

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -28,7 +28,7 @@ class ZajeciaForm(FlaskForm):
     data = DateField('Data konsultacji', validators=[DataRequired()])
     godzina_od = TimeField('Godzina od', validators=[DataRequired()])
     godzina_do = TimeField('Godzina do', validators=[DataRequired()])
-    beneficjenci = MultiCheckboxField(
+    beneficjenci = SelectMultipleField(
         'Beneficjenci', coerce=int, validators=[DataRequired()]
     )
     submit = SubmitField('Zapisz zajęcia')

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -18,13 +18,8 @@
     {{ form.godzina_do(class="form-control") }}
   </div>
   <div class="mb-3">
-    <label class="form-label">Beneficjenci</label>
-    {% for subfield in form.beneficjenci %}
-      <div class="form-check">
-        {{ subfield(class="form-check-input") }}
-        {{ form.beneficjenci.choices[loop.index0][1] }}
-      </div>
-    {% endfor %}
+    {{ form.beneficjenci.label(class="form-label") }}
+    {{ form.beneficjenci(class="form-select", multiple=True) }}
   </div>
   <button type="submit" class="btn btn-success">{{ form.submit.label.text }}</button>
 </form>

--- a/tests/test_beneficjent_pdf.py
+++ b/tests/test_beneficjent_pdf.py
@@ -87,7 +87,7 @@ def test_create_session(app, client):
             'data': '2023-01-01',
             'godzina_od': '10:00',
             'godzina_do': '11:00',
-            'beneficjenci': [str(b_id)],
+            'beneficjenci': str(b_id),
         },
         follow_redirects=True,
     )


### PR DESCRIPTION
## Summary
- switch `beneficjenci` field in `ZajeciaForm` to `SelectMultipleField`
- render a `<select multiple>` element in the session form
- adapt test to new field format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb8e9e4b4832a98c70418fed75b8a