### PR TITLE
Fix redirect for new sessions

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -168,7 +168,7 @@ def nowe_zajecia():
         db.session.add(zajecia)
         db.session.commit()
         flash('Zajęcia zapisane.')
-        return redirect(url_for('index'))
+        return redirect(url_for('lista_zajec'))
 
     return render_template('zajecia_form.html', form=form)
 

--- a/tests/test_beneficjent_pdf.py
+++ b/tests/test_beneficjent_pdf.py
@@ -99,6 +99,7 @@ def test_create_session(app, client):
         },
         follow_redirects=True,
     )
+    assert response.request.path == '/zajecia'
     assert 'Zajęcia zapisane' in response.get_data(as_text=True)
     with app.app_context():
         zajecia = Zajecia.query.filter_by(user_id=user_id).first()


### PR DESCRIPTION
## Summary
- redirect after saving a session goes to session list
- check final path in test_create_session

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf0c1905c832a8dd5cff75e618dc2