### PR TITLE
Add icons for edit/delete

### DIFF
--- a/app/templates/admin/beneficjenci_list.html
+++ b/app/templates/admin/beneficjenci_list.html
@@ -19,10 +19,14 @@
       <td>{{ b.wojewodztwo }}</td>
       <td>{{ b.user.full_name }}</td>
       <td>
-        <a href="{{ url_for('admin_edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+        <a href="{{ url_for('admin_edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+          <i class="bi bi-pencil"></i>
+        </a>
         <form method="post" action="{{ url_for('admin_usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
           {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+            <i class="bi bi-trash"></i>
+          </button>
         </form>
       </td>
     </tr>

--- a/app/templates/admin/instructors_list.html
+++ b/app/templates/admin/instructors_list.html
@@ -17,10 +17,14 @@
       <td>{{ u.full_name }}</td>
       <td>{{ u.email }}</td>
       <td>
-        <a href="{{ url_for('admin_edytuj_instruktora', user_id=u.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+        <a href="{{ url_for('admin_edytuj_instruktora', user_id=u.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+          <i class="bi bi-pencil"></i>
+        </a>
         <form method="post" action="{{ url_for('admin_usun_instruktora', user_id=u.id) }}" style="display:inline;">
           {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+            <i class="bi bi-trash"></i>
+          </button>
         </form>
         <form method="post" action="{{ url_for('admin_promote_instruktora', user_id=u.id) }}" style="display:inline;">
           {{ promote_form.csrf_token }}

--- a/app/templates/admin/zajecia_list.html
+++ b/app/templates/admin/zajecia_list.html
@@ -19,10 +19,14 @@
       <td>{{ z.godzina_od.strftime('%H:%M') }} - {{ z.godzina_do.strftime('%H:%M') }}</td>
       <td>{{ z.user.full_name }}</td>
       <td>
-        <a href="{{ url_for('admin_edytuj_zajecia', zajecia_id=z.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+        <a href="{{ url_for('admin_edytuj_zajecia', zajecia_id=z.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+          <i class="bi bi-pencil"></i>
+        </a>
         <form method="post" action="{{ url_for('admin_usun_zajecia', zajecia_id=z.id) }}" style="display:inline;">
           {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+            <i class="bi bi-trash"></i>
+          </button>
         </form>
       </td>
     </tr>

--- a/app/templates/beneficjenci_list.html
+++ b/app/templates/beneficjenci_list.html
@@ -24,10 +24,14 @@
       <td>{{ b.imie }}</td>
       <td>{{ b.wojewodztwo }}</td>
       <td>
-        <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+        <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+          <i class="bi bi-pencil"></i>
+        </a>
         <form method="post" action="{{ url_for('usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
           {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');">Usuń</button>
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+            <i class="bi bi-trash"></i>
+          </button>
         </form>
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- display Bootstrap icons inside edit and delete buttons
- add `aria-label` attributes for accessibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf5376124832abc1db5cc6ae5a693