### PR TITLE
Add password change view and error pages

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -91,6 +91,21 @@ class PasswordResetForm(FlaskForm):
     submit = SubmitField('Zresetuj hasło')
 
 
+class PasswordChangeForm(FlaskForm):
+    """Form for authenticated users to change their password."""
+
+    old_password = PasswordField('Aktualne hasło', validators=[DataRequired()])
+    new_password = PasswordField('Nowe hasło', validators=[DataRequired()])
+    confirm = PasswordField(
+        'Potwierdź hasło',
+        validators=[
+            DataRequired(),
+            EqualTo('new_password', message='Hasła muszą się zgadzać'),
+        ],
+    )
+    submit = SubmitField('Zmień hasło')
+
+
 class BeneficjentForm(FlaskForm):
     """Form for adding or editing a beneficiary."""
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -32,6 +32,7 @@ from .forms import (
     RegisterForm,
     PasswordResetRequestForm,
     PasswordResetForm,
+    PasswordChangeForm,
     BeneficjentForm,
     DeleteForm,
     PromoteForm,
@@ -245,6 +246,22 @@ def reset_password(token):
         flash('Hasło zostało zresetowane.')
         return redirect(url_for('login'))
     return render_template('reset_password.html', form=form)
+
+
+@app.route('/change_password', methods=['GET', 'POST'])
+@login_required
+def change_password():
+    """Allow the current user to change their password."""
+    form = PasswordChangeForm()
+    if form.validate_on_submit():
+        if not current_user.check_password(form.old_password.data):
+            flash('Nieprawidłowe aktualne hasło.')
+        else:
+            current_user.set_password(form.new_password.data)
+            db.session.commit()
+            flash('Hasło zostało zmienione.')
+            return redirect(url_for('index'))
+    return render_template('change_password.html', form=form)
 
 
 @app.route('/zajecia')
@@ -533,3 +550,16 @@ def admin_ustawienia():
         flash('Ustawienia zapisane.')
         return redirect(url_for('admin_ustawienia'))
     return render_template('admin/settings_form.html', form=form)
+
+
+@app.errorhandler(404)
+def not_found_error(error):
+    """Render a custom 404 page."""
+    return render_template('404.html'), 404
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    """Render a custom 500 page."""
+    db.session.rollback()
+    return render_template('500.html'), 500

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}404{% endblock %}
+{% block content %}
+<h2>Nie znaleziono strony</h2>
+<p>Podana strona nie istnieje.</p>
+{% endblock %}

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Błąd serwera{% endblock %}
+{% block content %}
+<h2>Wystąpił błąd serwera</h2>
+<p>Spróbuj ponownie później.</p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,8 +49,11 @@
           </li>
           {% endif %}
         </ul>
-        {% if current_user.is_authenticated %}
-        <ul class="navbar-nav">
+       {% if current_user.is_authenticated %}
+       <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
+          </li>
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('logout') }}">Wyloguj</a>
           </li>
@@ -93,6 +96,9 @@
         </li>
         {% endif %}
         {% if current_user.is_authenticated %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
+        </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('logout') }}">Wyloguj</a>
         </li>

--- a/app/templates/change_password.html
+++ b/app/templates/change_password.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Zmiana hasła{% endblock %}
+{% block content %}
+<h2>Zmień hasło</h2>
+<div class="row justify-content-center text-center">
+  <div class="col-12 col-md-6">
+    <form method="post" class="text-start w-100" style="max-width: 400px;">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.old_password.label(class="form-label") }}
+    {{ form.old_password(class="form-control", type="password") }}
+  </div>
+  <div class="mb-3">
+    {{ form.new_password.label(class="form-label") }}
+    {{ form.new_password(class="form-control", type="password") }}
+  </div>
+  <div class="mb-3">
+    {{ form.confirm.label(class="form-label") }}
+    {{ form.confirm(class="form-control", type="password") }}
+  </div>
+  <button type="submit" class="btn btn-success btn-sm">{{ form.submit.label.text }}</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -1,0 +1,77 @@
+import pytest
+from app import db
+from app.models import User
+
+
+def create_user(app):
+    with app.app_context():
+        user = User(full_name='change', email='c@example.com')
+        user.set_password('old')
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def login(client):
+    return client.post(
+        '/login',
+        data={'full_name': 'change', 'password': 'old'},
+        follow_redirects=True,
+    )
+
+
+def test_change_password_requires_login(client):
+    resp = client.get('/change_password', follow_redirects=True)
+    assert resp.request.path == '/login'
+
+
+def test_change_password_success(app, client):
+    create_user(app)
+    login(client)
+    resp = client.post(
+        '/change_password',
+        data={
+            'old_password': 'old',
+            'new_password': 'new',
+            'confirm': 'new',
+        },
+        follow_redirects=True,
+    )
+    assert 'Hasło zostało zmienione' in resp.get_data(as_text=True)
+    with app.app_context():
+        user = User.query.filter_by(full_name='change').first()
+        assert user.check_password('new')
+
+
+def test_change_password_wrong_old(app, client):
+    create_user(app)
+    login(client)
+    resp = client.post(
+        '/change_password',
+        data={
+            'old_password': 'bad',
+            'new_password': 'new',
+            'confirm': 'new',
+        },
+        follow_redirects=True,
+    )
+    assert 'Nieprawidłowe aktualne hasło' in resp.get_data(as_text=True)
+
+
+def test_custom_error_pages(app, client):
+    create_user(app)
+
+    @app.route('/cause_error')
+    def cause_error():
+        raise RuntimeError('boom')
+
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    resp = client.get('/nonexistent')
+    assert resp.status_code == 404
+    assert 'Nie znaleziono strony' in resp.get_data(as_text=True)
+
+    resp = client.get('/cause_error')
+    assert resp.status_code == 500
+    assert 'Wystąpił błąd serwera' in resp.get_data(as_text=True)
+


### PR DESCRIPTION
## Summary
- implement `PasswordChangeForm`
- add `/change_password` route and templates
- show change password link in navigation
- register error handlers with custom 404/500 templates
- test password change flow and custom error pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfda94b40832ab89f47688a11d71d