### PR TITLE
Wrap settings form in grid

### DIFF
--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -2,28 +2,32 @@
 {% block title %}Ustawienia{% endblock %}
 {% block content %}
 <h2>Ustawienia</h2>
-<form method="post" class="w-100" style="max-width: 400px;">
-  {{ form.csrf_token }}
-  <div class="mb-3">
-    {{ form.mail_server.label(class="form-label") }}
-    {{ form.mail_server(class="form-control") }}
+<div class="row justify-content-center text-center">
+  <div class="col-12 col-md-6">
+    <form method="post" class="text-start w-100" style="max-width: 400px;">
+      {{ form.csrf_token }}
+      <div class="mb-3">
+        {{ form.mail_server.label(class="form-label") }}
+        {{ form.mail_server(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.mail_port.label(class="form-label") }}
+        {{ form.mail_port(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.mail_username.label(class="form-label") }}
+        {{ form.mail_username(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.mail_password.label(class="form-label") }}
+        {{ form.mail_password(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.timezone.label(class="form-label") }}
+        {{ form.timezone(class="form-control") }}
+      </div>
+      {{ form.submit(class="btn btn-primary btn-sm") }}
+    </form>
   </div>
-  <div class="mb-3">
-    {{ form.mail_port.label(class="form-label") }}
-    {{ form.mail_port(class="form-control") }}
-  </div>
-  <div class="mb-3">
-    {{ form.mail_username.label(class="form-label") }}
-    {{ form.mail_username(class="form-control") }}
-  </div>
-  <div class="mb-3">
-    {{ form.mail_password.label(class="form-label") }}
-    {{ form.mail_password(class="form-control") }}
-  </div>
-  <div class="mb-3">
-    {{ form.timezone.label(class="form-label") }}
-    {{ form.timezone(class="form-control") }}
-  </div>
-  {{ form.submit(class="btn btn-primary btn-sm") }}
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- adjust `settings_form.html` to use Bootstrap grid layout similar to login/register

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0988e1c8832a9b6a74238cccad2d