### PR TITLE
Fix PDF generation blank page

### DIFF
--- a/app/pdf_generator.py
+++ b/app/pdf_generator.py
@@ -30,6 +30,7 @@ def generate_pdf(zajecia, beneficjenci, output_path):
         c.drawString(70, y, f"{benef.imie}")
         c.drawString(300, y, f"{benef.wojewodztwo}")
 
+    c.showPage()
     c.save()
 
     buffer.seek(0)

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -1,0 +1,46 @@
+"""Tests ensuring generated PDF files contain the expected text."""
+
+from datetime import date, time
+import os
+import tempfile
+
+from pypdf import PdfReader
+
+from app import db
+from app.models import User, Beneficjent, Zajecia
+from app.pdf_generator import generate_pdf
+
+
+def test_generate_pdf_file_contains_text(app):
+    """PDF generated on disk should include overlayed session data."""
+
+    with app.app_context():
+        user = User(full_name="disk", email="disk@example.com")
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+
+        benef = Beneficjent(imie="Tomek", wojewodztwo="Mazowieckie", user_id=user.id)
+        db.session.add(benef)
+        zajecia = Zajecia(
+            data=date(2023, 3, 3),
+            godzina_od=time(10, 0),
+            godzina_do=time(11, 0),
+            specjalista="disk",
+            user_id=user.id,
+        )
+        zajecia.beneficjenci.append(benef)
+        db.session.add(zajecia)
+        db.session.commit()
+
+        fd, path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
+        try:
+            generate_pdf(zajecia, [benef], path)
+            reader = PdfReader(path)
+            text = "".join(page.extract_text() or "" for page in reader.pages)
+            assert "disk" in text
+            assert "Tomek" in text
+        finally:
+            os.remove(path)
+


### PR DESCRIPTION
## Summary
- ensure the PDF canvas finalizes a page before saving
- add regression test verifying generated PDF files contain text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0f66f640832a99130e9197d49705