### PR TITLE
Adjust registration success message

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -119,7 +119,7 @@ def register():
                 )
                 flash('Nie udało się wysłać powiadomienia do administratora.')
 
-        flash('Rejestracja zakończona sukcesem.')
+        flash('Rejestracja zakończona sukcesem. Poczekaj na potwierdzenie przez administratora.')
         return redirect(url_for('login'))
     return render_template('register.html', form=form)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -149,7 +149,10 @@ def test_register_email_failure(monkeypatch, client, app):
     )
     assert response.status_code == 200
     text = response.get_data(as_text=True)
-    assert 'Rejestracja zakończona sukcesem.' in text
+    assert (
+        'Rejestracja zakończona sukcesem. Poczekaj na potwierdzenie przez administratora.'
+        in text
+    )
     assert 'Nie udało się wysłać powiadomienia do administratora.' in text
     with app.app_context():
         assert User.query.filter_by(full_name='fail').first() is not None


### PR DESCRIPTION
## Summary
- tweak the success flash in `register()`
- update auth tests for new flash text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1c39ef4c832a82d59567930d82e1