### PR TITLE
Ensure admin confirmation on app init

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,6 +114,9 @@ def create_app(test_config=None):
         if admin_username and admin_password:
             from .models import User, Roles
             admin = User.query.filter_by(full_name=admin_username).first()
+            if admin and not admin.confirmed:
+                admin.confirmed = True
+                db.session.commit()
             if not admin:
                 admin = User(
                     full_name=admin_username,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -70,6 +70,14 @@ def test_admin_created_from_env(monkeypatch):
         assert admin.email == 'admin@example.com'
         assert admin.check_password('adminpass')
         assert admin.role == 'admin'
+        assert admin.confirmed
+
+    # create_app called again should not alter admin confirmation status
+    app2 = create_app(config)
+    with app2.app_context():
+        admin = User.query.filter_by(full_name='admin').first()
+        assert admin is not None
+        assert admin.confirmed
 
 
 def test_register_and_login_remember_me(client, app):


### PR DESCRIPTION
## Summary
- confirm existing admin user when creating the app
- extend admin creation test to check confirmation on multiple app initializations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d3ae933f4832a94fc513d1247ccfa