### PR TITLE
Fix unconfirmed login flash

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -83,11 +83,11 @@ def login():
         if user and user.check_password(form.password.data):
             if not user.confirmed:
                 flash('Twoje konto nie zostało jeszcze potwierdzone.')
-            else:
-                login_user(user, remember=form.remember_me.data)
-                if not next_url or urlparse(next_url).netloc != "":
-                    next_url = url_for('nowe_zajecia')
-                return redirect(next_url)
+                return render_template('login.html', form=form)
+            login_user(user, remember=form.remember_me.data)
+            if not next_url or urlparse(next_url).netloc != "":
+                next_url = url_for('nowe_zajecia')
+            return redirect(next_url)
         flash('Nieprawidłowe dane logowania.')
     return render_template('login.html', form=form)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -232,4 +232,5 @@ def test_unconfirmed_user_cannot_login(app):
     )
     text = resp.get_data(as_text=True)
     assert 'Twoje konto nie zostało jeszcze potwierdzone.' in text
+    assert 'Nieprawidłowe dane logowania.' not in text
     assert 'Nowe zajęcia' not in text


### PR DESCRIPTION
## Summary
- handle unconfirmed user login in `login` view
- extend test to verify only the unconfirmed flash message appears

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d3c0898f0832ab4c9e147e1cdb150