### PR TITLE
Switch to docxtpl-based PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A small Flask application that lets specialists register sessions with beneficia
    pip install -r requirements.txt
    ```
    The `email_validator` package is included in `requirements.txt` and must
-   be installed for form validation to work correctly.
+   be installed for form validation to work correctly. The file now also
+   lists `docxtpl` and `docx2pdf` which are used to generate PDF reports.
 2. Copy `.env.example` to `.env` and set values for `SECRET_KEY`,
    `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
    A secure `SECRET_KEY` is required in **all** environments and there is
@@ -42,6 +43,10 @@ A small Flask application that lets specialists register sessions with beneficia
    ```bash
    flask --app run.py run
    ```
+6. PDF generation uses the `wzor.docx` template filled with session data and
+   converted to PDF using **docx2pdf**. Ensure a working copy of Microsoft
+   Word or LibreOffice is available if you run the application outside the
+   provided Docker container.
 
 ## Creating a user
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ flask-wtf
 flask-sqlalchemy
 Flask-Migrate
 werkzeug
-reportlab
 pypdf
+docxtpl
+docx2pdf
 python-dotenv
 Flask-Mail
 email_validator

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -5,14 +5,57 @@ import os
 import tempfile
 
 from pypdf import PdfReader
+from docx import Document
+import app.pdf_generator as pdfgen
+
+
+def _create_pdf(text, path):
+    """Write a minimal PDF containing *text* used for testing."""
+    text = text.replace('(', '\\(').replace(')', '\\)')
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    stream = f"BT /F1 12 Tf 50 800 Td ({text}) Tj ET"
+    encoded = stream.encode('latin-1', 'ignore')
+    objects.append(f"<< /Length {len(encoded)} >>\nstream\n{stream}\nendstream")
+    content = ['%PDF-1.4']
+    offsets = []
+    offset = len(content[0]) + 1
+    for i, obj in enumerate(objects, start=1):
+        offsets.append(offset)
+        part = f"{i} 0 obj\n{obj}\nendobj"
+        content.append(part)
+        offset += len(part) + 1
+    xref_offset = offset
+    xref = ["xref", f"0 {len(objects)+1}", "0000000000 65535 f "]
+    for off in offsets:
+        xref.append(f"{off:010d} 00000 n ")
+    content.append("\n".join(xref))
+    content.append(f"trailer\n<< /Root 1 0 R /Size {len(objects)+1} >>")
+    content.append(f"startxref\n{xref_offset}")
+    content.append("%%EOF")
+    with open(path, 'wb') as f:
+        f.write("\n".join(content).encode('latin-1', 'ignore'))
+
+
+def fake_convert(docx_path, pdf_path):
+    from flask import current_app
+    ctx = current_app.config.get("_last_pdf_context", {})
+    text = " \n".join(str(v) for v in ctx.values())
+    _create_pdf(text, pdf_path)
 
 from app import db
 from app.models import User, Beneficjent, Zajecia
 from app.pdf_generator import generate_pdf
 
 
-def test_generate_pdf_file_contains_text(app):
-    """PDF generated on disk should include overlayed session data."""
+def test_generate_pdf_file_contains_text(app, monkeypatch):
+    """PDF generated on disk should include rendered session data."""
+
+    monkeypatch.setattr(pdfgen, "convert", fake_convert)
 
     with app.app_context():
         user = User(full_name="disk", email="disk@example.com")


### PR DESCRIPTION
## Summary
- use `docxtpl` and `docx2pdf` for generating PDFs
- update README with new dependencies and conversion step
- stub docx2pdf in tests and adjust to new PDF creation
- remove ReportLab usage from `pdf_generator`

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d49420ef4832a9aa24483a4310bd8