### PR TITLE
Implement searchable dropdowns

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -155,7 +155,9 @@ def nowe_zajecia():
     form = ZajeciaForm()
     form.beneficjenci.choices = [
         (b.id, f"{b.imie} ({b.wojewodztwo})")
-        for b in Beneficjent.query.filter_by(user_id=current_user.id).all()
+        for b in Beneficjent.query.filter_by(user_id=current_user.id)
+        .order_by(Beneficjent.imie)
+        .all()
     ]
 
     # Ustawienie domyślnych godzin po zaokrągleniu

--- a/app/static/dropdown_search.js
+++ b/app/static/dropdown_search.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('select.form-select').forEach(select => {
+    const search = document.createElement('input');
+    search.type = 'text';
+    search.placeholder = 'Szukaj...';
+    search.className = 'form-control mb-2';
+
+    const options = Array.from(select.options);
+
+    search.addEventListener('input', () => {
+      const value = search.value.toLowerCase();
+      options.forEach(option => {
+        const text = option.textContent.toLowerCase();
+        option.hidden = !text.includes(value);
+      });
+    });
+
+    select.parentNode.insertBefore(search, select);
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -120,5 +120,6 @@
     </div>
   </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='dropdown_search.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add generic dropdown search script
- include the script in base layout
- sort beneficiaries alphabetically when creating sessions

## Testing
- `pytest -q`
- `flake8` *(fails: E501 and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_688d4e004e80832a9d2d4f4617db5640