### PR TITLE
Ensure DOCX reports aren't tracked

### DIFF
--- a/app/static/docx/.gitignore
+++ b/app/static/docx/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated DOCX reports
+*.docx


### PR DESCRIPTION
## Summary
- Keep generated consultation reports out of version control by ignoring `app/static/docx/*.docx`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e154b932c832a828f235e8160c471