### PR TITLE
Rename PDF column to Raport and update download link

### DIFF
--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -15,7 +15,7 @@
       <th>Data</th>
       <th>Godziny</th>
       <th>Specjalista</th>
-      <th>DOCX</th>
+      <th>Raport</th>
     </tr>
   </thead>
   <tbody>
@@ -25,7 +25,7 @@
       <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
       <td>{{ zaj.specjalista }}</td>
       <td>
-        <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz DOCX</a>
+        <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz raport</a>
       </td>
     </tr>
     {% else %}


### PR DESCRIPTION
## Summary
- rename session list header from PDF to Raport
- point report download link at `pobierz_docx` and label it “Pobierz raport”

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e16a0db18832aa52f6567d9e5466f