### PR TITLE
Document DOCX report workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt requirements.txt
-RUN apt-get update \
-    && apt-get install -y libreoffice \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ A small Flask application that lets specialists register sessions with beneficia
 6. Report generation uses the `wzor.docx` template filled with session data
    and saves the result as a DOCX file.
 
+## DOCX reports
+
+The `app/docx_generator.py` module renders session details into the
+`static/wzor.docx` template using **python-docx**. From the session list view
+you can click **Pobierz raport** to hit the `/zajecia/<id>/docx` endpoint which
+generates the document, serves it for download, and cleans up the temporary
+file afterwards.
+
 ## Creating a user
 
 Before logging in for the first time you must add at least one account. Launch a


### PR DESCRIPTION
## Summary
- clarify DOCX report generation and download flow in README
- drop unnecessary LibreOffice install from Dockerfile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2463c034832a9beadd03baafb784