### PR TITLE
Refine navbar width and add hover styles

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,9 @@
+.navbar-nav .nav-link {
+    padding: 0.25rem 0.75rem;
+}
+
+.navbar-nav .nav-link:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 0.25rem;
+}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,6 +6,7 @@
   <title>{% block title %}Konsultacje{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body class="bg-light text-dark pb-5">
   <header class="bg-white border-bottom py-2 mb-3">
@@ -16,8 +17,7 @@
   </header>
   {% if current_user.is_authenticated %}
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="{{ url_for('index') }}">Konsultacje</a>
+    <div class="container">
       <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
## Summary
- remove navbar brand text and use fixed-width `.container` so the menu aligns with page content
- add custom stylesheet for compact nav padding and hover background

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e407faa98832abe87791ace495d45