### PR TITLE
Style logout links with Bootstrap danger button

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -7,3 +7,7 @@
     border-radius: 0.25rem;
 }
 
+.logout-btn:hover {
+    opacity: 0.85;
+}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,7 +52,7 @@
             <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('logout') }}">Wyloguj</a>
+            <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
           </li>
         </ul>
         {% endif %}
@@ -94,7 +94,7 @@
           <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('logout') }}">Wyloguj</a>
+          <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
         </li>
         {% endif %}
       </ul>


### PR DESCRIPTION
## Summary
- Style logout link as small Bootstrap danger button in navbar and mobile menu
- Add hover opacity tweak for logout button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e41a4ebec832a97547a4a2246dd49