### PR TITLE
Use application timezone for session defaults

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,6 +3,7 @@
 import os
 import re
 from datetime import datetime, timedelta
+import pytz
 
 from flask import (
     current_app as app,
@@ -169,7 +170,8 @@ def nowe_zajecia():
 
     # Ustawienie domyślnych godzin po zaokrągleniu
     if request.method == 'GET':
-        now = datetime.now()
+        tz = pytz.timezone(current_app.config['TIMEZONE'])
+        now = datetime.now(tz)
         rounded = (
             now + timedelta(minutes=30 - now.minute % 30)
         ).replace(second=0, microsecond=0)


### PR DESCRIPTION
## Summary
- import pytz and use the configured timezone when initializing consultation forms
- compute rounded times and default date using timezone-aware `now`

## Testing
- `pytest -q`
- manual form rendering check (status 200, expected date/time)


------
https://chatgpt.com/codex/tasks/task_e_688e4334141c832abd788bf6919b5409