### PR TITLE
Add user settings page

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -111,6 +111,30 @@ class PasswordChangeForm(FlaskForm):
     submit = SubmitField('Zmień hasło')
 
 
+class UserSettingsForm(FlaskForm):
+    """Form allowing users to update their details and password."""
+
+    email = EmailField('Email', validators=[DataRequired(), Email()])
+    full_name = StringField('Imię i nazwisko', validators=[DataRequired()])
+    default_duration = IntegerField(
+        'Domyślny czas trwania (min)', validators=[DataRequired()]
+    )
+    old_password = PasswordField(
+        'Aktualne hasło', validators=[Optional()]
+    )
+    new_password = PasswordField(
+        'Nowe hasło', validators=[Optional()]
+    )
+    confirm = PasswordField(
+        'Potwierdź hasło',
+        validators=[
+            Optional(),
+            EqualTo('new_password', message='Hasła muszą się zgadzać'),
+        ],
+    )
+    submit = SubmitField('Zapisz')
+
+
 class BeneficjentForm(FlaskForm):
     """Form for adding or editing a beneficiary."""
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,7 +49,7 @@
        {% if current_user.is_authenticated %}
        <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
+            <a class="nav-link" href="{{ url_for('user_settings') }}">Ustawienia</a>
           </li>
           <li class="nav-item">
             <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
@@ -91,7 +91,7 @@
         {% endif %}
         {% if current_user.is_authenticated %}
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('change_password') }}">Zmień hasło</a>
+          <a class="nav-link" href="{{ url_for('user_settings') }}">Ustawienia</a>
         </li>
         <li class="nav-item">
           <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}Ustawienia użytkownika{% endblock %}
+{% block content %}
+<h2>Ustawienia użytkownika</h2>
+<div class="row justify-content-center text-center">
+  <div class="col-12 col-md-6">
+    <form method="post" class="text-start w-100" style="max-width: 400px;">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">
+        {{ form.full_name.label(class="form-label") }}
+        {{ form.full_name(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.email.label(class="form-label") }}
+        {{ form.email(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.default_duration.label(class="form-label") }}
+        {{ form.default_duration(class="form-control") }}
+      </div>
+      <hr>
+      <div class="mb-3">
+        {{ form.old_password.label(class="form-label") }}
+        {{ form.old_password(class="form-control", type="password") }}
+      </div>
+      <div class="mb-3">
+        {{ form.new_password.label(class="form-label") }}
+        {{ form.new_password(class="form-control", type="password") }}
+      </div>
+      <div class="mb-3">
+        {{ form.confirm.label(class="form-label") }}
+        {{ form.confirm(class="form-control", type="password") }}
+      </div>
+      <div class="text-center">
+        <button type="submit" class="btn btn-success btn-sm">{{ form.submit.label.text }}</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -21,35 +21,41 @@ def login(client):
     )
 
 
-def test_change_password_requires_login(client):
-    resp = client.get('/change_password', follow_redirects=True)
+def test_settings_requires_login(client):
+    resp = client.get('/settings', follow_redirects=True)
     assert resp.request.path == '/login'
 
 
-def test_change_password_success(app, client):
+def test_settings_password_change_success(app, client):
     create_user(app)
     login(client)
     resp = client.post(
-        '/change_password',
+        '/settings',
         data={
+            'email': 'c@example.com',
+            'full_name': 'change',
+            'default_duration': 90,
             'old_password': 'old',
             'new_password': 'new',
             'confirm': 'new',
         },
         follow_redirects=True,
     )
-    assert 'Hasło zostało zmienione' in resp.get_data(as_text=True)
+    assert 'Ustawienia zapisane' in resp.get_data(as_text=True)
     with app.app_context():
         user = User.query.filter_by(full_name='change').first()
         assert user.check_password('new')
 
 
-def test_change_password_wrong_old(app, client):
+def test_settings_wrong_old_password(app, client):
     create_user(app)
     login(client)
     resp = client.post(
-        '/change_password',
+        '/settings',
         data={
+            'email': 'c@example.com',
+            'full_name': 'change',
+            'default_duration': 90,
             'old_password': 'bad',
             'new_password': 'new',
             'confirm': 'new',


### PR DESCRIPTION
## Summary
- add `UserSettingsForm` for editing email, name, default duration and changing password
- replace `/change_password` with `/settings` route and template
- update navigation to point to the new settings page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e466a1c14832a8f30cc9ffe95f7a4