### PR TITLE
Allow selecting one beneficiary per session

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -53,8 +53,8 @@ class ZajeciaForm(FlaskForm):
     data = DateField('Data konsultacji', validators=[DataRequired()])
     godzina_od = TimeField('Godzina od', validators=[DataRequired()])
     godzina_do = TimeField('Godzina do', validators=[DataRequired()])
-    beneficjenci = SelectMultipleField(
-        'Beneficjenci', coerce=int, validators=[DataRequired()]
+    beneficjenci = SelectField(
+        'Beneficjent', coerce=int, validators=[DataRequired()]
     )
     submit = SubmitField('Zapisz zajęcia')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -189,9 +189,8 @@ def nowe_zajecia():
             specjalista=current_user.full_name,
             user_id=current_user.id
         )
-        for b_id in form.beneficjenci.data:
-            beneficjent = db.session.get(Beneficjent, b_id)
-            zajecia.beneficjenci.append(beneficjent)
+        beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
+        zajecia.beneficjenci = [beneficjent]
 
         db.session.add(zajecia)
         db.session.commit()
@@ -489,14 +488,14 @@ def admin_edytuj_zajecia(zajecia_id):
         for b in Beneficjent.query.filter_by(user_id=zajecia.user_id).all()
     ]
     if request.method == 'GET':
-        form.beneficjenci.data = [b.id for b in zajecia.beneficjenci]
+        if zajecia.beneficjenci:
+            form.beneficjenci.data = zajecia.beneficjenci[0].id
     if form.validate_on_submit():
         zajecia.data = form.data.data
         zajecia.godzina_od = form.godzina_od.data
         zajecia.godzina_do = form.godzina_do.data
-        zajecia.beneficjenci = [
-            db.session.get(Beneficjent, i) for i in form.beneficjenci.data
-        ]
+        beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
+        zajecia.beneficjenci = [beneficjent]
         db.session.commit()
         flash('Zajęcia zaktualizowane.')
         return redirect(url_for('admin_zajecia'))

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -19,7 +19,7 @@
   </div>
   <div class="mb-3">
     {{ form.beneficjenci.label(class="form-label") }}
-    {{ form.beneficjenci(class="form-select", multiple=True) }}
+    {{ form.beneficjenci(class="form-select") }}
   </div>
   <div class="text-center">
     <button type="submit" class="btn btn-success btn-sm">{{ form.submit.label.text }}</button>


### PR DESCRIPTION
## Summary
- replace multi-select beneficiary field with single-select
- update session creation and edit routes to store one beneficiary
- render beneficiary dropdown as a standard `<select>`

## Testing
- `pytest`
- `flake8` *(fails: line too long, unused imports, blank line at end of file)*

------
https://chatgpt.com/codex/tasks/task_e_688e48e68c34832a925ab3d6c34a94cb