### PR TITLE
Add calendar view and JSON API for sessions

### DIFF
--- a/app/templates/zajecia_calendar.html
+++ b/app/templates/zajecia_calendar.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Kalendarz zajęć{% endblock %}
+{% block content %}
+<h2>Kalendarz zajęć</h2>
+<div id="calendar"></div>
+
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var calendarEl = document.getElementById('calendar');
+  var calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    events: '{{ url_for("api_zajecia") }}'
+  });
+  calendar.render();
+});
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add `/kalendarz` route with calendar and `/api/zajecia` JSON endpoint
- create `zajecia_calendar.html` integrating FullCalendar

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4aa81970832a9b5fdd42b3f70c1b