### PR TITLE
Add time range validation to session form

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -13,7 +13,13 @@ from wtforms import (
     IntegerField,
     BooleanField,
 )
-from wtforms.validators import DataRequired, Email, EqualTo, Optional
+from wtforms.validators import (
+    DataRequired,
+    Email,
+    EqualTo,
+    Optional,
+    ValidationError,
+)
 import pytz
 from wtforms.widgets import ListWidget, CheckboxInput
 
@@ -54,9 +60,21 @@ class ZajeciaForm(FlaskForm):
     godzina_od = TimeField('Godzina od', validators=[DataRequired()])
     godzina_do = TimeField('Godzina do', validators=[DataRequired()])
     beneficjenci = SelectField(
-        'Beneficjent', coerce=int, validators=[DataRequired()]
+        'Beneficjent', coerce=int, validators=[DataRequired()] 
     )
     submit = SubmitField('Zapisz zajęcia')
+
+    def validate(self, extra_validators=None):  # pragma: no cover - custom logic
+        """Ensure the end time is later than the start time."""
+        if not super().validate(extra_validators):
+            return False
+        if self.godzina_do.data <= self.godzina_od.data:
+            message = (
+                'Godzina zakończenia musi być późniejsza niż godzina rozpoczęcia.'
+            )
+            self.godzina_do.errors.append(message)
+            raise ValidationError(message)
+        return True
 
 
 class RegisterForm(FlaskForm):

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -12,10 +12,16 @@
   <div class="mb-3">
     {{ form.godzina_od.label(class="form-label") }}
     {{ form.godzina_od(class="form-control") }}
+    {% for error in form.godzina_od.errors %}
+      <div class="text-danger">{{ error }}</div>
+    {% endfor %}
   </div>
   <div class="mb-3">
     {{ form.godzina_do.label(class="form-label") }}
     {{ form.godzina_do(class="form-control") }}
+    {% for error in form.godzina_do.errors %}
+      <div class="text-danger">{{ error }}</div>
+    {% endfor %}
   </div>
   <div class="mb-3">
     {{ form.beneficjenci.label(class="form-label") }}

--- a/tests/test_zajecia_form.py
+++ b/tests/test_zajecia_form.py
@@ -1,0 +1,20 @@
+import pytest
+from wtforms.validators import ValidationError
+from app.forms import ZajeciaForm
+
+
+def test_invalid_time_range_raises_error(app):
+    """ZajeciaForm should raise ValidationError when end time precedes start."""
+    with app.test_request_context('/', method='POST'):
+        form = ZajeciaForm(
+            data={
+                'data': '2023-01-01',
+                'godzina_od': '10:00',
+                'godzina_do': '09:00',
+                'beneficjenci': 1,
+            }
+        )
+        form.beneficjenci.choices = [(1, 'Test')]
+        with pytest.raises(ValidationError):
+            form.validate()
+        assert form.godzina_do.errors


### PR DESCRIPTION
## Summary
- ensure ZajeciaForm rejects sessions where end time is not after start time
- show validation feedback for time fields in zajecia form template
- test that invalid time range triggers a validation error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e4c97d1f8832a815d425b9b5ec9ce