### PR TITLE
Add tests for settings, beneficiary selection and DOCX route

### DIFF
--- a/tests/test_beneficjent_field.py
+++ b/tests/test_beneficjent_field.py
@@ -1,0 +1,60 @@
+import re
+from datetime import date, time
+
+from app import db
+from app.models import User, Beneficjent, Zajecia
+
+
+def create_user(app):
+    with app.app_context():
+        user = User(full_name='field', email='field@example.com')
+        user.set_password('secret')
+        user.confirmed = True
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def login(client):
+    return client.post(
+        '/login',
+        data={'full_name': 'field', 'password': 'secret'},
+        follow_redirects=True,
+    )
+
+
+def add_beneficjent(app, user_id, name='Jan'):
+    with app.app_context():
+        benef = Beneficjent(imie=name, wojewodztwo='Mazowieckie', user_id=user_id)
+        db.session.add(benef)
+        db.session.commit()
+        return benef.id
+
+
+def test_beneficjent_field_renders_single_choice(app, client):
+    user_id = create_user(app)
+    add_beneficjent(app, user_id)
+    login(client)
+    resp = client.get('/zajecia/nowe')
+    html = resp.get_data(as_text=True)
+    match = re.search(r'<select[^>]*name="beneficjenci"[^>]*>', html)
+    assert match is not None
+    assert 'multiple' not in match.group(0)
+
+
+def test_beneficjent_field_requires_selection(app, client):
+    user_id = create_user(app)
+    add_beneficjent(app, user_id)
+    login(client)
+    resp = client.post(
+        '/zajecia/nowe',
+        data={
+            'data': '2023-01-01',
+            'godzina_od': '10:00',
+            'godzina_do': '11:00',
+        },
+        follow_redirects=True,
+    )
+    assert resp.request.path == '/zajecia/nowe'
+    with app.app_context():
+        assert Zajecia.query.count() == 0

--- a/tests/test_docx_route.py
+++ b/tests/test_docx_route.py
@@ -1,0 +1,69 @@
+import io
+from datetime import date, time
+
+from docx import Document
+
+from app import db
+from app.models import User, Beneficjent, Zajecia
+
+
+def create_user(app, name='doc', email=None):
+    with app.app_context():
+        user = User(full_name=name, email=email or f'{name}@example.com')
+        user.set_password('secret')
+        user.confirmed = True
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def login(client, name='doc'):
+    return client.post(
+        '/login',
+        data={'full_name': name, 'password': 'secret'},
+        follow_redirects=True,
+    )
+
+
+def create_session(app, user_id):
+    with app.app_context():
+        benef = Beneficjent(imie='Benef', wojewodztwo='Mazowieckie', user_id=user_id)
+        db.session.add(benef)
+        zaj = Zajecia(
+            data=date(2023, 1, 1),
+            godzina_od=time(9, 0),
+            godzina_do=time(10, 0),
+            specjalista='spec',
+            user_id=user_id,
+        )
+        zaj.beneficjenci.append(benef)
+        db.session.add(zaj)
+        db.session.commit()
+        return zaj.id
+
+
+def test_docx_route_returns_valid_file(app, client):
+    user_id = create_user(app)
+    login(client)
+    z_id = create_session(app, user_id)
+    resp = client.get(f'/zajecia/{z_id}/docx')
+    assert resp.status_code == 200
+    assert 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' in resp.headers.get('Content-Type', '')
+    Document(io.BytesIO(resp.data))
+
+
+def test_docx_route_requires_ownership(app, client):
+    owner_id = create_user(app, name='owner', email='owner@example.com')
+    z_id = create_session(app, owner_id)
+    create_user(app, name='other', email='other@example.com')
+    login(client, name='other')
+    resp = client.get(f'/zajecia/{z_id}/docx')
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/')
+
+
+def test_docx_route_missing_session_returns_404(app, client):
+    create_user(app)
+    login(client)
+    resp = client.get('/zajecia/999/docx')
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- verify settings form renders user details and handles missing required fields
- ensure beneficiary selection is single-choice and required
- check DOCX download route returns valid files and handles error states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e561c2be8832a9591c39c8b27c2dc