### PR TITLE
Use email for login

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -25,8 +25,8 @@ from flask_login import (
     logout_user,
 )
 from flask_wtf import FlaskForm
-from wtforms import PasswordField, StringField, SubmitField, BooleanField
-from wtforms.validators import DataRequired, ValidationError
+from wtforms import PasswordField, SubmitField, BooleanField, EmailField
+from wtforms.validators import DataRequired, ValidationError, Email
 from flask_mail import Message
 from smtplib import SMTPException
 
@@ -69,7 +69,7 @@ def admin_required(view_func):
 class LoginForm(FlaskForm):
     """Form used by users to authenticate to the application."""
 
-    full_name = StringField('Login', validators=[DataRequired()])
+    email = EmailField('Email', validators=[DataRequired(), Email()])
     password = PasswordField('Hasło', validators=[DataRequired()])
     remember_me = BooleanField('Zapamiętaj mnie')
     submit = SubmitField('Zaloguj się')
@@ -81,7 +81,7 @@ def login():
     next_url = request.args.get('next')
     form = LoginForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(full_name=form.full_name.data).first()
+        user = User.query.filter_by(email=form.email.data).first()
         if user and user.check_password(form.password.data):
             if not user.confirmed:
                 flash('Twoje konto nie zostało jeszcze potwierdzone.')

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,8 +7,8 @@
     <form method="post" class="text-start w-100" style="max-width: 400px;">
   {{ form.hidden_tag() }}
   <div class="mb-3">
-    {{ form.full_name.label(class="form-label") }}
-    {{ form.full_name(class="form-control", **{'aria-label': 'Login'}) }}
+    {{ form.email.label(class="form-label") }}
+    {{ form.email(class="form-control", **{'aria-label': 'Email'}) }}
   </div>
   <div class="mb-3">
     {{ form.password.label(class="form-label") }}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -102,7 +102,7 @@ def test_register_and_login_remember_me(client, app):
         db.session.commit()
 
     response = client.post('/login', data={
-        'full_name': 'alice',
+        'email': 'alice@example.com',
         'password': 'password',
         'remember_me': 'y',
     }, follow_redirects=True)
@@ -210,7 +210,7 @@ def test_password_reset_flow(monkeypatch, app):
 
     response = client.post(
         '/login',
-        data={'full_name': 'bob', 'password': 'newpass'},
+        data={'email': 'bob@example.com', 'password': 'newpass'},
         follow_redirects=True,
     )
     assert b'Nowe zaj\xc4\x99cia' in response.data
@@ -227,7 +227,7 @@ def test_unconfirmed_user_cannot_login(app):
     client = app.test_client()
     resp = client.post(
         '/login',
-        data={'full_name': 'unc', 'password': 'pass'},
+        data={'email': 'unc@example.com', 'password': 'pass'},
         follow_redirects=True,
     )
     text = resp.get_data(as_text=True)

--- a/tests/test_beneficjent_docx.py
+++ b/tests/test_beneficjent_docx.py
@@ -38,12 +38,12 @@ def create_user(app):
         return user.id
 
 
-def login(client, username='tester', password='secret'):
+def login(client, email='tester@example.com', password='secret'):
     """Log in a user using the test client."""
 
     return client.post(
         '/login',
-        data={'full_name': username, 'password': password},
+        data={'email': email, 'password': password},
         follow_redirects=True,
     )
 

--- a/tests/test_beneficjent_field.py
+++ b/tests/test_beneficjent_field.py
@@ -18,7 +18,7 @@ def create_user(app):
 def login(client):
     return client.post(
         '/login',
-        data={'full_name': 'field', 'password': 'secret'},
+        data={'email': 'field@example.com', 'password': 'secret'},
         follow_redirects=True,
     )
 

--- a/tests/test_docx_route.py
+++ b/tests/test_docx_route.py
@@ -17,10 +17,10 @@ def create_user(app, name='doc', email=None):
         return user.id
 
 
-def login(client, name='doc'):
+def login(client, name='doc', email=None):
     return client.post(
         '/login',
-        data={'full_name': name, 'password': 'secret'},
+        data={'email': email or f'{name}@example.com', 'password': 'secret'},
         follow_redirects=True,
     )
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -36,9 +36,14 @@ def create_users(app):
 def login(client, username):
     """Authenticate a test user and return the response."""
 
+    email_map = {
+        'admin': 'admin@example.com',
+        'inst1': 'i1@example.com',
+        'inst2': 'i2@example.com',
+    }
     return client.post(
         '/login',
-        data={'full_name': username, 'password': 'pass'},
+        data={'email': email_map.get(username, f'{username}@example.com'), 'password': 'pass'},
         follow_redirects=True,
     )
 
@@ -112,7 +117,7 @@ def test_confirm_instructor(app):
     # Unconfirmed user should not be able to log in
     resp = client.post(
         '/login',
-        data={'full_name': 'newbie', 'password': 'pass'},
+        data={'email': 'newbie@example.com', 'password': 'pass'},
         follow_redirects=True,
     )
     assert 'Twoje konto nie zostało jeszcze potwierdzone.' in resp.get_data(as_text=True)
@@ -135,7 +140,7 @@ def test_confirm_instructor(app):
     # User should now be able to log in
     resp = client.post(
         '/login',
-        data={'full_name': 'newbie', 'password': 'pass'},
+        data={'email': 'newbie@example.com', 'password': 'pass'},
         follow_redirects=True,
     )
     assert 'Nowe zajęcia' in resp.get_data(as_text=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -43,7 +43,7 @@ def login(client):
 
     return client.post(
         "/login",
-        data={"full_name": "test", "password": "secret"},
+        data={"email": "test@example.com", "password": "secret"},
         follow_redirects=True,
     )
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,7 +57,7 @@ def create_admin(app, admin_email=None, sender_name=None):
 def login(client):
     return client.post(
         '/login',
-        data={'full_name': 'admin', 'password': 'pass'},
+        data={'email': 'admin@example.com', 'password': 'pass'},
         follow_redirects=True,
     )
 

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -16,7 +16,7 @@ def create_user(app):
 def login(client):
     return client.post(
         '/login',
-        data={'full_name': 'change', 'password': 'old'},
+        data={'email': 'c@example.com', 'password': 'old'},
         follow_redirects=True,
     )
 

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -57,7 +57,7 @@ def test_beneficjenci_mobile_view(app, live_server, driver):
         db.session.commit()
     driver.set_window_size(375, 812)
     driver.get(live_server + "/login")
-    driver.find_element("name", "full_name").send_keys("mob")
+    driver.find_element("name", "email").send_keys("m@b.com")
     driver.find_element("name", "password").send_keys("pass")
     driver.find_element("css selector", "button[type=submit]").click()
     driver.get(live_server + "/beneficjenci")


### PR DESCRIPTION
## Summary
- use `EmailField` and `Email` validator for login form and authenticate by email
- update login template and tests to submit the email field instead of username
- ensure repo references to login use email

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e5ae672b0832a8847cdcb77a4e531