### PR TITLE
Use label clicks for dropdown selection

### DIFF
--- a/app/static/dropdown_search.js
+++ b/app/static/dropdown_search.js
@@ -27,20 +27,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const options = Array.from(select.options).map((option) => {
       const label = document.createElement('label');
-      label.className = 'dropdown-item d-flex align-items-center';
-      const input = document.createElement('input');
-      input.type = select.multiple ? 'checkbox' : 'radio';
-      input.className = 'form-check-input me-2';
-      input.checked = option.selected;
-      label.appendChild(input);
+      label.className = 'dropdown-item';
       label.appendChild(document.createTextNode(option.textContent));
+      if (option.selected) {
+        label.classList.add('active');
+      }
       optionsContainer.appendChild(label);
 
-      input.addEventListener('change', () => {
+      label.addEventListener('click', () => {
         if (select.multiple) {
-          option.selected = input.checked;
-        } else if (input.checked) {
+          option.selected = !option.selected;
+          label.classList.toggle('active', option.selected);
+        } else {
           select.value = option.value;
+          options.forEach(({ label: lbl }) => lbl.classList.remove('active'));
+          label.classList.add('active');
+          bootstrap.Dropdown.getOrCreateInstance(button).hide();
         }
         updateButtonText();
       });


### PR DESCRIPTION
## Summary
- Remove input elements from dropdown options and drive selection with label clicks
- Highlight active options and hide dropdown on choice

## Testing
- `node <test snippet>`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e62a21a2c832a973e93eaf31a9735