### PR TITLE
Enable live search for sessions and beneficiaries

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -339,6 +339,10 @@ def lista_zajec():
         query.order_by(Zajecia.data.desc(), Zajecia.godzina_od.desc()).all()
     )
     delete_form = DeleteForm()
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return render_template(
+            '_zajecia_rows.html', zajecia_list=zajecia_list, delete_form=delete_form
+        )
     return render_template(
         'zajecia_list.html', zajecia_list=zajecia_list, q=q, delete_form=delete_form
     )
@@ -447,6 +451,12 @@ def lista_beneficjentow():
         )
     beneficjenci = query.all()
     delete_form = DeleteForm()
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return render_template(
+            '_beneficjenci_rows.html',
+            beneficjenci=beneficjenci,
+            delete_form=delete_form,
+        )
     return render_template(
         'beneficjenci_list.html',
         beneficjenci=beneficjenci,

--- a/app/static/live_search.js
+++ b/app/static/live_search.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const debounce = (fn, delay = 300) => {
+    let timeout;
+    return (...args) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(null, args), delay);
+    };
+  };
+
+  document.querySelectorAll('[data-live-search]').forEach(input => {
+    const targetSelector = input.dataset.liveSearch;
+    const target = document.querySelector(targetSelector);
+    if (!target) return;
+
+    const handler = debounce(async () => {
+      const params = new URLSearchParams(window.location.search);
+      if (input.value) {
+        params.set('q', input.value);
+      } else {
+        params.delete('q');
+      }
+      const url = `${window.location.pathname}?${params.toString()}`;
+      try {
+        const resp = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+        if (resp.ok) {
+          const html = await resp.text();
+          target.innerHTML = html;
+        }
+      } catch (err) {
+        console.error('Live search failed', err);
+      }
+    });
+
+    input.addEventListener('input', handler);
+  });
+});

--- a/app/templates/_beneficjenci_rows.html
+++ b/app/templates/_beneficjenci_rows.html
@@ -1,0 +1,19 @@
+{% for b in beneficjenci %}
+<tr>
+  <td>{{ b.imie }}</td>
+  <td>{{ b.wojewodztwo }}</td>
+  <td>
+    <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+      <i class="bi bi-pencil"></i>
+    </a>
+    <form method="post" action="{{ url_for('usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
+      {{ delete_form.csrf_token }}
+      <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+        <i class="bi bi-trash"></i>
+      </button>
+    </form>
+  </td>
+</tr>
+{% else %}
+<tr><td colspan="3">Brak beneficjentów.</td></tr>
+{% endfor %}

--- a/app/templates/_zajecia_rows.html
+++ b/app/templates/_zajecia_rows.html
@@ -1,0 +1,23 @@
+{% for zaj in zajecia_list %}
+<tr>
+  <td>{{ zaj.data.strftime('%d.%m.%Y') }}</td>
+  <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
+  <td>{{ zaj.specjalista }}</td>
+  <td>
+    <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz raport</a>
+  </td>
+  <td>
+    <a href="{{ url_for('edytuj_zajecia', zajecia_id=zaj.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
+      <i class="bi bi-pencil"></i>
+    </a>
+    <form method="post" action="{{ url_for('usun_zajecia', zajecia_id=zaj.id) }}" style="display:inline;">
+      {{ delete_form.csrf_token }}
+      <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
+        <i class="bi bi-trash"></i>
+      </button>
+    </form>
+  </td>
+</tr>
+{% else %}
+<tr><td colspan="5">Brak zajęć.</td></tr>
+{% endfor %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -122,5 +122,6 @@
   </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='dropdown_search.js') }}"></script>
+  <script src="{{ url_for('static', filename='live_search.js') }}"></script>
 </body>
 </html>

--- a/app/templates/beneficjenci_list.html
+++ b/app/templates/beneficjenci_list.html
@@ -4,8 +4,7 @@
 <h2>Beneficjenci</h2>
 <form method="get" class="mb-3">
   <div class="input-group">
-    <input type="text" name="q" class="form-control" placeholder="Szukaj" value="{{ q }}">
-    <button class="btn btn-primary btn-sm" type="submit">Szukaj</button>
+    <input id="beneficjenci-search" data-live-search="#beneficjenci-rows" type="text" name="q" class="form-control" placeholder="Szukaj" value="{{ q }}">
   </div>
 </form>
 <a href="{{ url_for('nowy_beneficjent') }}" class="btn btn-success btn-sm mb-3">Dodaj beneficjenta</a>
@@ -18,26 +17,8 @@
       <th>Akcje</th>
     </tr>
   </thead>
-  <tbody>
-    {% for b in beneficjenci %}
-    <tr>
-      <td>{{ b.imie }}</td>
-      <td>{{ b.wojewodztwo }}</td>
-      <td>
-        <a href="{{ url_for('edytuj_beneficjenta', beneficjent_id=b.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
-          <i class="bi bi-pencil"></i>
-        </a>
-        <form method="post" action="{{ url_for('usun_beneficjenta', beneficjent_id=b.id) }}" style="display:inline;">
-          {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
-            <i class="bi bi-trash"></i>
-          </button>
-        </form>
-      </td>
-    </tr>
-    {% else %}
-    <tr><td colspan="3">Brak beneficjentów.</td></tr>
-    {% endfor %}
+  <tbody id="beneficjenci-rows">
+    {% include '_beneficjenci_rows.html' %}
   </tbody>
 </table>
 </div>

--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -4,8 +4,7 @@
 <h2>Lista zajęć</h2>
 <form method="get" class="mb-3">
   <div class="input-group">
-    <input type="text" name="q" class="form-control" placeholder="Szukaj" value="{{ q }}">
-    <button class="btn btn-primary btn-sm" type="submit">Szukaj</button>
+    <input id="zajecia-search" data-live-search="#zajecia-rows" type="text" name="q" class="form-control" placeholder="Szukaj" value="{{ q }}">
   </div>
 </form>
 <div class="table-responsive">
@@ -19,30 +18,8 @@
       <th>Akcje</th>
     </tr>
   </thead>
-  <tbody>
-    {% for zaj in zajecia_list %}
-    <tr>
-      <td>{{ zaj.data.strftime('%d.%m.%Y') }}</td>
-      <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
-      <td>{{ zaj.specjalista }}</td>
-      <td>
-        <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz raport</a>
-      </td>
-      <td>
-        <a href="{{ url_for('edytuj_zajecia', zajecia_id=zaj.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
-          <i class="bi bi-pencil"></i>
-        </a>
-        <form method="post" action="{{ url_for('usun_zajecia', zajecia_id=zaj.id) }}" style="display:inline;">
-          {{ delete_form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
-            <i class="bi bi-trash"></i>
-          </button>
-        </form>
-      </td>
-    </tr>
-    {% else %}
-    <tr><td colspan="5">Brak zajęć.</td></tr>
-    {% endfor %}
+  <tbody id="zajecia-rows">
+    {% include '_zajecia_rows.html' %}
   </tbody>
 </table>
 </div>


### PR DESCRIPTION
## Summary
- Add live search inputs and table body containers for `zajecia` and `beneficjenci` lists
- Implement debounced AJAX fetching and dynamic row updates via `live_search.js`
- Serve row fragments from `lista_zajec` and `lista_beneficjentow` for partial page updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f7fb723a0832ab7c37d454c965f4e