### PR TITLE
Handle consultation time validation without exceptions

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -18,7 +18,6 @@ from wtforms.validators import (
     Email,
     EqualTo,
     Optional,
-    ValidationError,
 )
 import pytz
 from wtforms.widgets import ListWidget, CheckboxInput
@@ -73,7 +72,7 @@ class ZajeciaForm(FlaskForm):
                 'Godzina zakończenia musi być późniejsza niż godzina rozpoczęcia.'
             )
             self.godzina_do.errors.append(message)
-            raise ValidationError(message)
+            return False
         return True
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -189,24 +189,21 @@ def nowe_zajecia():
             rounded + timedelta(minutes=current_user.default_duration)
         ).time()
 
-    try:
-        if form.validate_on_submit():
-            zajecia = Zajecia(
-                data=form.data.data,
-                godzina_od=form.godzina_od.data,
-                godzina_do=form.godzina_do.data,
-                specjalista=current_user.full_name,
-                user_id=current_user.id,
-            )
-            beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
-            zajecia.beneficjenci = [beneficjent]
+    if form.validate_on_submit():
+        zajecia = Zajecia(
+            data=form.data.data,
+            godzina_od=form.godzina_od.data,
+            godzina_do=form.godzina_do.data,
+            specjalista=current_user.full_name,
+            user_id=current_user.id,
+        )
+        beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
+        zajecia.beneficjenci = [beneficjent]
 
-            db.session.add(zajecia)
-            db.session.commit()
-            flash('Zajęcia zapisane.')
-            return redirect(url_for('lista_zajec'))
-    except ValidationError:
-        pass
+        db.session.add(zajecia)
+        db.session.commit()
+        flash('Zajęcia zapisane.')
+        return redirect(url_for('lista_zajec'))
 
     return render_template('zajecia_form.html', form=form)
 
@@ -365,18 +362,15 @@ def edytuj_zajecia(zajecia_id):
     if request.method == 'GET' and zajecia.beneficjenci:
         form.beneficjenci.data = zajecia.beneficjenci[0].id
 
-    try:
-        if form.validate_on_submit():
-            zajecia.data = form.data.data
-            zajecia.godzina_od = form.godzina_od.data
-            zajecia.godzina_do = form.godzina_do.data
-            beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
-            zajecia.beneficjenci = [beneficjent]
-            db.session.commit()
-            flash('Zajęcia zaktualizowane.')
-            return redirect(url_for('lista_zajec'))
-    except ValidationError:
-        pass
+    if form.validate_on_submit():
+        zajecia.data = form.data.data
+        zajecia.godzina_od = form.godzina_od.data
+        zajecia.godzina_do = form.godzina_do.data
+        beneficjent = db.session.get(Beneficjent, form.beneficjenci.data)
+        zajecia.beneficjenci = [beneficjent]
+        db.session.commit()
+        flash('Zajęcia zaktualizowane.')
+        return redirect(url_for('lista_zajec'))
 
     return render_template('zajecia_form.html', form=form)
 

--- a/tests/test_zajecia_form.py
+++ b/tests/test_zajecia_form.py
@@ -1,10 +1,8 @@
-import pytest
-from wtforms.validators import ValidationError
 from app.forms import ZajeciaForm
 
 
-def test_invalid_time_range_raises_error(app):
-    """ZajeciaForm should raise ValidationError when end time precedes start."""
+def test_invalid_time_range_returns_error(app):
+    """Form.validate should return False and set an error for invalid times."""
     with app.test_request_context('/', method='POST'):
         form = ZajeciaForm(
             data={
@@ -15,6 +13,5 @@ def test_invalid_time_range_raises_error(app):
             }
         )
         form.beneficjenci.choices = [(1, 'Test')]
-        with pytest.raises(ValidationError):
-            form.validate()
+        assert not form.validate()
         assert form.godzina_do.errors


### PR DESCRIPTION
## Summary
- Stop raising `ValidationError` in `ZajeciaForm`; instead append the error and return `False` so WTForms handles it.
- Simplify `nowe_zajecia` and `edytuj_zajecia` views by letting `validate_on_submit()` manage time errors.
- Tests updated to assert `validate()` returns `False` when the end time is earlier than the start time.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f84b12f54832aa282da724d53a4d2