### PR TITLE
Refactor navigation into macro with active link highlighting

### DIFF
--- a/app/templates/_nav_macros.html
+++ b/app/templates/_nav_macros.html
@@ -1,0 +1,34 @@
+{% macro render_nav_items(admin_id) %}
+  <li class="nav-item">
+    <a class="nav-link{% if request.endpoint == 'nowe_zajecia' %} active{% endif %}" href="{{ url_for('nowe_zajecia') }}"{% if request.endpoint == 'nowe_zajecia' %} aria-current="page"{% endif %}>Nowe zajęcia</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link{% if request.endpoint == 'lista_zajec' %} active{% endif %}" href="{{ url_for('lista_zajec') }}"{% if request.endpoint == 'lista_zajec' %} aria-current="page"{% endif %}>Lista zajęć</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link{% if request.endpoint == 'lista_beneficjentow' %} active{% endif %}" href="{{ url_for('lista_beneficjentow') }}"{% if request.endpoint == 'lista_beneficjentow' %} aria-current="page"{% endif %}>Beneficjenci</a>
+  </li>
+  {% if current_user.is_authenticated and current_user.role == 'admin' %}
+  {% set admin_endpoints = ['admin_instruktorzy', 'admin_beneficjenci', 'admin_zajecia', 'admin_ustawienia'] %}
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle{% if request.endpoint in admin_endpoints %} active{% endif %}" href="#" id="{{ admin_id }}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{% if request.endpoint in admin_endpoints %} aria-current="page"{% endif %}>Admin</a>
+    <ul class="dropdown-menu" aria-labelledby="{{ admin_id }}">
+      <li><a class="dropdown-item{% if request.endpoint == 'admin_instruktorzy' %} active{% endif %}" href="{{ url_for('admin_instruktorzy') }}"{% if request.endpoint == 'admin_instruktorzy' %} aria-current="page"{% endif %}>Instruktorzy</a></li>
+      <li><a class="dropdown-item{% if request.endpoint == 'admin_beneficjenci' %} active{% endif %}" href="{{ url_for('admin_beneficjenci') }}"{% if request.endpoint == 'admin_beneficjenci' %} aria-current="page"{% endif %}>Beneficjenci</a></li>
+      <li><a class="dropdown-item{% if request.endpoint == 'admin_zajecia' %} active{% endif %}" href="{{ url_for('admin_zajecia') }}"{% if request.endpoint == 'admin_zajecia' %} aria-current="page"{% endif %}>Zajęcia</a></li>
+      <li><a class="dropdown-item{% if request.endpoint == 'admin_ustawienia' %} active{% endif %}" href="{{ url_for('admin_ustawienia') }}"{% if request.endpoint == 'admin_ustawienia' %} aria-current="page"{% endif %}>Ustawienia</a></li>
+    </ul>
+  </li>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_user_items() %}
+  {% if current_user.is_authenticated %}
+  <li class="nav-item">
+    <a class="nav-link{% if request.endpoint == 'user_settings' %} active{% endif %}" href="{{ url_for('user_settings') }}"{% if request.endpoint == 'user_settings' %} aria-current="page"{% endif %}>Ustawienia</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
+  </li>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body class="bg-light text-dark pb-5">
+  {% from '_nav_macros.html' import render_nav_items, render_user_items with context %}
   <header class="bg-white border-bottom py-2 mb-3">
     <div class="container d-flex align-items-center">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo" class="me-2" style="height: 40px;">
@@ -23,39 +24,11 @@
       </button>
       <div class="d-none d-lg-flex flex-grow-1 justify-content-between" id="navbarNav">
         <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('lista_zajec') }}">Lista zajęć</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('lista_beneficjentow') }}">Beneficjenci</a>
-          </li>
-          {% if current_user.is_authenticated and current_user.role == 'admin' %}
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="adminMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Admin
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="adminMenu">
-              <li><a class="dropdown-item" href="{{ url_for('admin_instruktorzy') }}">Instruktorzy</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin_beneficjenci') }}">Beneficjenci</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin_zajecia') }}">Zajęcia</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin_ustawienia') }}">Ustawienia</a></li>
-            </ul>
-          </li>
-          {% endif %}
+          {{ render_nav_items('adminMenu') }}
         </ul>
-       {% if current_user.is_authenticated %}
-       <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('user_settings') }}">Ustawienia</a>
-          </li>
-          <li class="nav-item">
-            <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
-          </li>
+        <ul class="navbar-nav">
+          {{ render_user_items() }}
         </ul>
-        {% endif %}
       </div>
     </div>
   </nav>
@@ -67,36 +40,8 @@
     </div>
     <div class="offcanvas-body">
       <ul class="navbar-nav flex-grow-1 pe-3 justify-content-center">
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('nowe_zajecia') }}">Nowe zajęcia</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('lista_zajec') }}">Lista zajęć</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('lista_beneficjentow') }}">Beneficjenci</a>
-        </li>
-        {% if current_user.is_authenticated and current_user.role == 'admin' %}
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="adminMenuMobile" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            Admin
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="adminMenuMobile">
-            <li><a class="dropdown-item" href="{{ url_for('admin_instruktorzy') }}">Instruktorzy</a></li>
-            <li><a class="dropdown-item" href="{{ url_for('admin_beneficjenci') }}">Beneficjenci</a></li>
-            <li><a class="dropdown-item" href="{{ url_for('admin_zajecia') }}">Zajęcia</a></li>
-            <li><a class="dropdown-item" href="{{ url_for('admin_ustawienia') }}">Ustawienia</a></li>
-          </ul>
-        </li>
-        {% endif %}
-        {% if current_user.is_authenticated %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('user_settings') }}">Ustawienia</a>
-        </li>
-        <li class="nav-item">
-          <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('logout') }}">Wyloguj</a>
-        </li>
-        {% endif %}
+        {{ render_nav_items('adminMenuMobile') }}
+        {{ render_user_items() }}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- consolidate navbar markup into `_nav_macros.html` macros
- highlight current page using `request.endpoint` with `active` and `aria-current` attributes
- apply macros across desktop and mobile menus

## Testing
- `pytest`
- `flake8` *(fails: line too long, trailing whitespace and unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_688f8ae514c8832aab06ff784337742d