### PR TITLE
Validate positive default duration in user settings

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -18,6 +18,7 @@ from wtforms.validators import (
     Email,
     EqualTo,
     Optional,
+    NumberRange,
 )
 import pytz
 from wtforms.widgets import ListWidget, CheckboxInput
@@ -134,7 +135,8 @@ class UserSettingsForm(FlaskForm):
     email = EmailField('Email', validators=[DataRequired(), Email()])
     full_name = StringField('Imię i nazwisko', validators=[DataRequired()])
     default_duration = IntegerField(
-        'Domyślny czas trwania (min)', validators=[DataRequired()]
+        'Domyślny czas trwania (min)',
+        validators=[DataRequired(), NumberRange(min=1)],
     )
     old_password = PasswordField(
         'Aktualne hasło', validators=[Optional()]

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -93,6 +93,27 @@ def test_settings_missing_required_fields_shows_errors(app, client):
         assert user.email == 'c@example.com'
 
 
+def test_settings_invalid_default_duration_shows_errors(app, client):
+    """Submitting a negative duration should re-render form and keep settings unchanged."""
+    create_user(app)
+    login(client)
+    resp = client.post(
+        '/settings',
+        data={
+            'email': 'c@example.com',
+            'full_name': 'change',
+            'default_duration': -5,
+        },
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Ustawienia zapisane' not in html
+    assert 'Ustawienia użytkownika' in html
+    with app.app_context():
+        user = User.query.filter_by(full_name='change').first()
+        assert user.default_duration == 90
+
+
 def test_custom_error_pages(app, client):
     create_user(app)
 


### PR DESCRIPTION
## Summary
- enforce positive default_duration via NumberRange validator
- cover negative default_duration submissions with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f8c7d5404832a8709092241fd9a70