### PR TITLE
Add email prompt for sending session docs

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -60,17 +60,20 @@ class ZajeciaForm(FlaskForm):
     godzina_od = TimeField('Godzina od', validators=[DataRequired()])
     godzina_do = TimeField('Godzina do', validators=[DataRequired()])
     beneficjenci = SelectField(
-        'Beneficjent', coerce=int, validators=[DataRequired()] 
+        'Beneficjent', coerce=int, validators=[DataRequired()]
     )
-    submit = SubmitField('Zapisz zajęcia')
+    submit = SubmitField('Zapisz')
+    submit_send = SubmitField('Zapisz i wyślij')
 
-    def validate(self, extra_validators=None):  # pragma: no cover - custom logic
+    def validate(self, extra_validators=None):
+        # pragma: no cover - custom logic
         """Ensure the end time is later than the start time."""
         if not super().validate(extra_validators):
             return False
         if self.godzina_do.data <= self.godzina_od.data:
             message = (
-                'Godzina zakończenia musi być późniejsza niż godzina rozpoczęcia.'
+                'Godzina zakończenia musi być późniejsza niż '
+                'godzina rozpoczęcia.'
             )
             self.godzina_do.errors.append(message)
             return False
@@ -205,7 +208,9 @@ class SettingsForm(FlaskForm):
     mail_password = PasswordField('Hasło SMTP')
     mail_use_tls = BooleanField('Użyj TLS')
     mail_use_ssl = BooleanField('Użyj SSL')
-    admin_email = EmailField('Email administratora', validators=[Optional(), Email()])
+    admin_email = EmailField(
+        'Email administratora', validators=[Optional(), Email()]
+    )
     sender_name = StringField('Nazwa nadawcy')
     timezone = SelectField('Strefa czasowa', choices=TIMEZONE_CHOICES)
     submit = SubmitField('Zapisz')

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -3,8 +3,9 @@
 {% block content %}
 <h2>Nowe zajęcia</h2>
 <div class="d-flex justify-content-center">
-<form method="post" class="text-start w-100" style="max-width: 400px;">
+<form method="post" class="text-start w-100" style="max-width: 400px;" id="zajecia-form">
   {{ form.hidden_tag() }}
+  <input type="hidden" name="recipient_email" id="recipient-email" value="{{ current_user.document_recipient_email or '' }}">
   <div class="mb-3">
     {{ form.data.label(class="form-label") }}
     {{ form.data(class="form-control") }}
@@ -28,8 +29,57 @@
     {{ form.beneficjenci(class="form-select") }}
   </div>
   <div class="text-center">
-    <button type="submit" class="btn btn-success btn-sm">{{ form.submit.label.text }}</button>
+    {{ form.submit(class="btn btn-success btn-sm me-2") }}
+    {{ form.submit_send(id="submit-send", class="btn btn-primary btn-sm") }}
   </div>
 </form>
 </div>
+
+<div class="modal fade" id="emailModal" tabindex="-1" aria-labelledby="emailModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="emailModalLabel">Podaj email</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <label for="modal-email" class="form-label">Email odbiorcy dokumentów</label>
+        <input type="email" id="modal-email" class="form-control">
+        <div class="form-text">Email można zmienić w ustawieniach.</div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
+        <button type="button" class="btn btn-primary" id="modal-submit">Wyślij</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const recipientEmail = "{{ current_user.document_recipient_email or '' }}";
+  const submitSend = document.getElementById('submit-send');
+  const form = document.getElementById('zajecia-form');
+  const modalEl = document.getElementById('emailModal');
+  const modal = new bootstrap.Modal(modalEl);
+
+  submitSend.addEventListener('click', function (event) {
+    if (!recipientEmail) {
+      event.preventDefault();
+      modal.show();
+    }
+  });
+
+  document.getElementById('modal-submit').addEventListener('click', function () {
+    const emailInput = document.getElementById('modal-email').value;
+    document.getElementById('recipient-email').value = emailInput;
+    const sendField = document.createElement('input');
+    sendField.type = 'hidden';
+    sendField.name = 'submit_send';
+    sendField.value = '1';
+    form.appendChild(sendField);
+    form.submit();
+  });
+});
+</script>
 {% endblock %}

--- a/tests/test_zajecia_form.py
+++ b/tests/test_zajecia_form.py
@@ -15,3 +15,10 @@ def test_invalid_time_range_returns_error(app):
         form.beneficjenci.choices = [(1, 'Test')]
         assert not form.validate()
         assert form.godzina_do.errors
+
+
+def test_form_has_submit_send(app):
+    """ZajeciaForm should include submit_send field."""
+    with app.test_request_context('/'):
+        form = ZajeciaForm()
+        assert 'submit_send' in form._fields


### PR DESCRIPTION
## Summary
- support sending sessions by adding `submit_send` button to `ZajeciaForm`
- show "Zapisz" and "Zapisz i wyślij" buttons with modal to collect recipient email when missing
- cover new submit action with unit test

## Testing
- `flake8 app/forms.py tests/test_zajecia_form.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892100f5484832ab5d34e63744922e0