### PR TITLE
Use async email delivery

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,8 @@
 """Flask application factory and extension initialization."""
 
 import os
-from flask import Flask
+from threading import Thread
+from flask import Flask, current_app
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_mail import Mail
@@ -14,6 +15,14 @@ login_manager = LoginManager()
 login_manager.login_view = 'login'
 mail = Mail()
 csrf = CSRFProtect()
+
+def send_async_email(app, msg):
+    with app.app_context():
+        mail.send(msg)
+
+
+def send_email(msg):
+    Thread(target=send_async_email, args=(current_app._get_current_object(), msg)).start()
 
 
 def create_app(test_config=None):

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,7 +45,7 @@ from .forms import (
     SettingsForm,
 )
 from .models import Beneficjent, User, Zajecia, Roles, Settings
-from . import mail
+from . import mail, send_email
 from .docx_generator import generate_docx
 from urllib.parse import urlparse
 from functools import wraps
@@ -137,7 +137,7 @@ def register():
                 f'{user.email}. Potwierdź konto: {confirm_url}'
             )
             try:
-                mail.send(msg)
+                send_email(msg)
             except SMTPException as e:
                 current_app.logger.error(
                     "Failed to send admin email: %s", e
@@ -236,7 +236,7 @@ def nowe_zajecia():
                             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                             f.read(),
                         )
-                    mail.send(msg)
+                    send_email(msg)
                     flash("Dokument wysłany.")
                 except (FileNotFoundError, SMTPException) as e:
                     current_app.logger.error(
@@ -334,7 +334,7 @@ def wyslij_docx(zajecia_id):
         )
 
     try:
-        mail.send(msg)
+        send_email(msg)
         flash("Raport wysłany ponownie.")
     except SMTPException as exc:
         current_app.logger.error("Failed to send session email: %s", exc)
@@ -372,7 +372,7 @@ def reset_password_request():
                 f'Kliknij link aby zresetować hasło: {reset_url}'
             )
             try:
-                mail.send(msg)
+                send_email(msg)
             except SMTPException as e:
                 current_app.logger.error(
                     "Failed to send password reset email: %s", e
@@ -879,7 +879,7 @@ def admin_ustawienia():
                 )
                 msg.body = 'To jest test konfiguracji SMTP.'
                 try:
-                    mail.send(msg)
+                    send_email(msg)
                     flash('Testowy email wysłany.')
                 except SMTPException as exc:
                     current_app.logger.error('Failed to send test email: %s', exc)

--- a/tests/test_async_email.py
+++ b/tests/test_async_email.py
@@ -1,0 +1,31 @@
+from flask_mail import Message
+from app import send_email
+
+
+def test_send_email_uses_thread(monkeypatch, app):
+    calls = []
+
+    def fake_async(app_obj, msg):
+        calls.append(msg)
+
+    monkeypatch.setattr('app.send_async_email', fake_async)
+
+    started = {'value': False}
+
+    class DummyThread:
+        def __init__(self, target, args=()):
+            assert target is fake_async
+            self.target = target
+            self.args = args
+        def start(self):
+            started['value'] = True
+            self.target(*self.args)
+
+    monkeypatch.setattr('app.Thread', DummyThread)
+
+    with app.app_context():
+        msg = Message('sub', recipients=['x@example.com'])
+        send_email(msg)
+
+    assert started['value']
+    assert calls and calls[0].recipients == ['x@example.com']

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -148,7 +148,7 @@ def test_register_email_failure(monkeypatch, client, app):
     def fail_send(msg):
         raise SMTPException('tls not supported')
 
-    monkeypatch.setattr('app.routes.mail.send', fail_send)
+    monkeypatch.setattr('app.routes.send_email', fail_send)
 
     response = client.post(
         '/register',
@@ -179,7 +179,7 @@ def test_register_sends_confirmation_email(monkeypatch, client, app):
     def fake_send(msg):
         sent.append(msg)
 
-    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.send_email', fake_send)
 
     response = client.post(
         '/register',
@@ -215,7 +215,7 @@ def test_password_reset_flow(monkeypatch, app):
     def fake_send(msg):
         sent.append(msg)
 
-    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.send_email', fake_send)
     client = app.test_client()
 
     response = client.post(

--- a/tests/test_docx_route.py
+++ b/tests/test_docx_route.py
@@ -109,7 +109,7 @@ def test_send_route_emails_docx(app, client, monkeypatch):
     def fake_send(msg):
         sent.append(msg)
 
-    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.send_email', fake_send)
 
     resp = client.get(f'/zajecia/{z_id}/send')
     assert resp.status_code == 302
@@ -134,7 +134,7 @@ def test_send_route_requires_ownership(app, client, monkeypatch):
     def fake_send(msg):
         sent.append(msg)
 
-    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.send_email', fake_send)
 
     resp = client.get(f'/zajecia/{z_id}/send')
     assert resp.status_code == 302

--- a/tests/test_send_docx_email.py
+++ b/tests/test_send_docx_email.py
@@ -45,7 +45,7 @@ def test_submit_send_dispatches_email_with_attachment(monkeypatch, app, client):
     def fake_generate_docx(zajecia, beneficjenci, output_path):
         Path(output_path).write_bytes(b'dummy')
 
-    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.send_email', fake_send)
     monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
 
     resp = client.post(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -132,7 +132,7 @@ def test_send_test_email_success(monkeypatch):
     def fake_send(msg):
         sent.append(msg)
 
-    monkeypatch.setattr("app.routes.mail.send", fake_send)
+    monkeypatch.setattr("app.routes.send_email", fake_send)
     client = app.test_client()
     login(client)
     resp = client.post(
@@ -163,7 +163,7 @@ def test_send_test_email_failure(monkeypatch):
     def fail_send(msg):
         raise SMTPException("boom")
 
-    monkeypatch.setattr("app.routes.mail.send", fail_send)
+    monkeypatch.setattr("app.routes.send_email", fail_send)
     client = app.test_client()
     login(client)
     resp = client.post(


### PR DESCRIPTION
## Summary
- add threaded helper to send emails asynchronously
- update routes to queue email delivery instead of sending inline
- cover async dispatch with new unit test and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921d96fdc8832aa1e06ee0e0f80cae