### PR TITLE
Track document email send time

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -95,6 +95,8 @@ class Zajecia(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     user = db.relationship('User')
 
+    doc_sent_at = db.Column(db.DateTime, nullable=True)
+
     beneficjenci = db.relationship(
         'Beneficjent', secondary='zajecia_beneficjenci'
     )

--- a/app/routes.py
+++ b/app/routes.py
@@ -237,6 +237,8 @@ def nowe_zajecia():
                             f.read(),
                         )
                     mail.send(msg)
+                    zajecia.doc_sent_at = datetime.utcnow()
+                    db.session.commit()
                     flash("Dokument wysłany.")
                 except (FileNotFoundError, SMTPException) as e:
                     current_app.logger.error(
@@ -335,6 +337,8 @@ def wyslij_docx(zajecia_id):
 
     try:
         mail.send(msg)
+        zajecia.doc_sent_at = datetime.utcnow()
+        db.session.commit()
         flash("Raport wysłany ponownie.")
     except SMTPException as exc:
         current_app.logger.error("Failed to send session email: %s", exc)

--- a/app/templates/_zajecia_rows.html
+++ b/app/templates/_zajecia_rows.html
@@ -3,6 +3,7 @@
   <td>{{ zaj.data.strftime('%d.%m.%Y') }}</td>
   <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
   <td>{{ zaj.specjalista }}</td>
+  <td>{{ 'wysłano' if zaj.doc_sent_at else 'niewysłano' }}</td>
   <td>
     <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz raport</a>
     <a href="{{ url_for('wyslij_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Wyślij ponownie</a>
@@ -20,5 +21,5 @@
   </td>
 </tr>
 {% else %}
-<tr><td colspan="5">Brak zajęć.</td></tr>
+<tr><td colspan="6">Brak zajęć.</td></tr>
 {% endfor %}

--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -14,6 +14,7 @@
       <th>Data</th>
       <th>Godziny</th>
       <th>Specjalista</th>
+      <th>Status</th>
       <th>Raporty</th>
       <th>Akcje</th>
     </tr>

--- a/migrations/versions/1c0c1ce4a3b0_add_doc_sent_at_to_zajecia.py
+++ b/migrations/versions/1c0c1ce4a3b0_add_doc_sent_at_to_zajecia.py
@@ -1,0 +1,24 @@
+"""add doc_sent_at column to zajecia
+
+Revision ID: 1c0c1ce4a3b0
+Revises: 65ed717d04cb
+Create Date: 2025-09-25 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1c0c1ce4a3b0'
+down_revision = '65ed717d04cb'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('zajecia', sa.Column('doc_sent_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('zajecia', 'doc_sent_at')

--- a/tests/test_docx_route.py
+++ b/tests/test_docx_route.py
@@ -118,6 +118,10 @@ def test_send_route_emails_docx(app, client, monkeypatch):
     assert sent[0].attachments
     assert sent[0].attachments[0].filename.endswith('.docx')
 
+    with app.app_context():
+        zaj = db.session.get(Zajecia, z_id)
+        assert zaj.doc_sent_at is not None
+
 
 def test_send_route_requires_ownership(app, client, monkeypatch):
     owner_id = create_user(app, name='owner', email='owner@example.com')

--- a/tests/test_send_docx_email.py
+++ b/tests/test_send_docx_email.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from app import db
-from app.models import User, Beneficjent
+from app.models import User, Beneficjent, Zajecia
 
 
 def create_user(app):
@@ -68,3 +68,7 @@ def test_submit_send_dispatches_email_with_attachment(monkeypatch, app, client):
 
     output_dir = Path(app.root_path) / 'static' / 'docx'
     assert not (output_dir / 'Konsultacje dietetyczne 2023-01-01 Ala.docx').exists()
+
+    with app.app_context():
+        zaj = Zajecia.query.one()
+        assert zaj.doc_sent_at is not None


### PR DESCRIPTION
## Summary
- add nullable `doc_sent_at` timestamp to `Zajecia` and migrate schema
- stamp `doc_sent_at` after sending document emails and show send status in session list
- test that email sending marks sessions as sent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892244ba38c832a827915996dca73e2