### PR TITLE
Add email logging and resend functionality

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -128,3 +128,19 @@ class Settings(db.Model):
     def get(cls):
         """Return the single settings row or ``None`` if absent."""
         return cls.query.first()
+
+
+class SentEmail(db.Model):
+    """Log entry for a sent email related to a session."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    zajecia_id = db.Column(
+        db.Integer, db.ForeignKey('zajecia.id'), nullable=False
+    )
+    recipient = db.Column(db.String(120), nullable=False)
+    subject = db.Column(db.String(255), nullable=False)
+    sent_at = db.Column(db.DateTime, nullable=True)
+    status = db.Column(db.String(20), nullable=False)
+    file_path = db.Column(db.String(255), nullable=True)
+
+    zajecia = db.relationship('Zajecia', backref='sent_emails')

--- a/app/templates/_nav_macros.html
+++ b/app/templates/_nav_macros.html
@@ -6,6 +6,9 @@
     <a class="nav-link{% if request.endpoint == 'lista_zajec' %} active{% endif %}" href="{{ url_for('lista_zajec') }}"{% if request.endpoint == 'lista_zajec' %} aria-current="page"{% endif %}>Lista zajęć</a>
   </li>
   <li class="nav-item">
+    <a class="nav-link{% if request.endpoint == 'emails_list' %} active{% endif %}" href="{{ url_for('emails_list') }}"{% if request.endpoint == 'emails_list' %} aria-current="page"{% endif %}>Wiadomości</a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link{% if request.endpoint == 'lista_beneficjentow' %} active{% endif %}" href="{{ url_for('lista_beneficjentow') }}"{% if request.endpoint == 'lista_beneficjentow' %} aria-current="page"{% endif %}>Beneficjenci</a>
   </li>
   {% if current_user.is_authenticated and current_user.role == 'admin' %}

--- a/app/templates/emails_list.html
+++ b/app/templates/emails_list.html
@@ -1,0 +1,38 @@
+{% block title %}Wysłane wiadomości{% endblock %}
+{% block content %}
+<h2>Wysłane wiadomości</h2>
+<div class="table-responsive">
+<table class="table mx-auto text-start">
+  <thead>
+    <tr>
+      <th>Zajęcia</th>
+      <th>Odbiorca</th>
+      <th>Temat</th>
+      <th>Wysłano</th>
+      <th>Status</th>
+      <th>Akcje</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for email in emails %}
+    <tr>
+      <td>{{ email.zajecia.data.strftime('%d.%m.%Y') if email.zajecia else '' }}</td>
+      <td>{{ email.recipient }}</td>
+      <td>{{ email.subject }}</td>
+      <td>{{ email.sent_at.strftime('%Y-%m-%d %H:%M') if email.sent_at else '' }}</td>
+      <td>{{ email.status }}</td>
+      <td>
+        {% if email.zajecia %}
+        <a href="{{ url_for('pobierz_docx', zajecia_id=email.zajecia_id) }}" class="btn btn-sm btn-secondary">Pobierz</a>
+        <a href="{{ url_for('resend_email', email_id=email.id) }}" class="btn btn-sm btn-secondary">Wyślij ponownie</a>
+        {% endif %}
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="6">Brak wysłanych wiadomości.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+{% endblock %}
+

--- a/migrations/versions/b7fee1a97eeb_add_sent_email_model.py
+++ b/migrations/versions/b7fee1a97eeb_add_sent_email_model.py
@@ -1,0 +1,37 @@
+"""add sent_email model
+
+Revision ID: b7fee1a97eeb
+Revises: 1c0c1ce4a3b0
+Create Date: 2025-10-04 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7fee1a97eeb'
+down_revision = '1c0c1ce4a3b0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'sent_email',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('zajecia_id', sa.Integer(), nullable=False),
+        sa.Column('recipient', sa.String(length=120), nullable=False),
+        sa.Column('subject', sa.String(length=255), nullable=False),
+        sa.Column('sent_at', sa.DateTime(), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('file_path', sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(['zajecia_id'], ['zajecia.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade():
+    op.drop_table('sent_email')
+

--- a/tests/test_email_logs.py
+++ b/tests/test_email_logs.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from app import db
+from app.models import User, Beneficjent, SentEmail
+
+
+def create_user(app):
+    with app.app_context():
+        user = User(
+            full_name='sender',
+            email='sender@example.com',
+            document_recipient_email='dest@example.com',
+        )
+        user.set_password('secret')
+        user.confirmed = True
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def login(client):
+    return client.post(
+        '/login',
+        data={'email': 'sender@example.com', 'password': 'secret'},
+        follow_redirects=True,
+    )
+
+
+def test_email_log_and_resend(monkeypatch, app, client):
+    user_id = create_user(app)
+    login(client)
+    with app.app_context():
+        benef = Beneficjent(
+            imie='Ala', wojewodztwo='Mazowieckie', user_id=user_id
+        )
+        db.session.add(benef)
+        db.session.commit()
+        b_id = benef.id
+
+    messages = []
+
+    def fake_send(msg):
+        messages.append(msg)
+
+    def fake_generate_docx(zajecia, beneficjenci, output_path):
+        Path(output_path).write_bytes(b'dummy')
+
+    monkeypatch.setattr('app.routes.mail.send', fake_send)
+    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+
+    resp = client.post(
+        '/zajecia/nowe',
+        data={
+            'data': '2023-01-01',
+            'godzina_od': '10:00',
+            'godzina_do': '11:00',
+            'beneficjenci': str(b_id),
+            'submit_send': '1',
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert len(messages) == 1
+
+    with app.app_context():
+        log = SentEmail.query.one()
+        assert log.recipient == 'dest@example.com'
+        assert log.status == 'sent'
+        first_sent_at = log.sent_at
+        email_id = log.id
+
+    resp = client.get('/emails')
+    assert resp.status_code == 200
+    assert b'dest@example.com' in resp.data
+
+    resp = client.get(f'/emails/{email_id}/resend', follow_redirects=True)
+    assert resp.status_code == 200
+    assert len(messages) == 2
+
+    with app.app_context():
+        log = SentEmail.query.get(email_id)
+        assert log.status == 'sent'
+        assert log.sent_at != first_sent_at
+


### PR DESCRIPTION
## Summary
- Log all outgoing session emails with new `SentEmail` model and migration
- Track send attempts in session creation and resend routes
- Provide `/emails` view and resend action with navigation link and template
- Add integration test for email logging and resend behavior

## Testing
- `pytest -q`
- `flake8` *(fails: line length/style issues in pre-existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68922fb327c0832aa71169976b2551d5