### PR TITLE
Replace dietetykiem placeholder in generated docx

### DIFF
--- a/tests/test_docx_generator.py
+++ b/tests/test_docx_generator.py
@@ -1,5 +1,6 @@
 """Tests ensuring generated DOCX files contain the expected text."""
 
+import os
 from datetime import date, time
 from docx import Document
 
@@ -48,3 +49,7 @@ def test_generate_docx_file_contains_text(app, tmp_path):
         text = _docx_text(doc)
         assert "disk" in text
         assert "Tomek" in text
+        assert "dietetykiem" not in text
+
+        template = Document(os.path.join(app.root_path, "static", "wzor.docx"))
+        assert "dietetykiem" in _docx_text(template)


### PR DESCRIPTION
## Summary
- Replace occurrences of "dietetykiem" with the provided instructor across all paragraphs and table cells when generating DOCX files.
- Load the template in-memory to ensure the template on disk is never modified.
- Add tests confirming "dietetykiem" is absent from generated documents and replaced with the instructor value while the template remains unchanged.

## Testing
- `pytest tests/test_docx_generator.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893552ff51c832abfde9434743f4a29