### PR TITLE
Use requestSubmit for zajecia form

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -63,7 +63,7 @@ class ZajeciaForm(FlaskForm):
     beneficjenci = SelectField(
         'Beneficjent', coerce=int, validators=[DataRequired()]
     )
-    submit = SubmitField('Zapisz')
+    save = SubmitField('Zapisz')
     submit_send = SubmitField('Zapisz i wyślij')
 
     def validate(self, extra_validators=None):

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -33,7 +33,7 @@
     {{ form.beneficjenci(class="form-select") }}
   </div>
   <div class="text-center">
-    {{ form.submit(class="btn btn-success btn-sm me-2") }}
+    {{ form.save(class="btn btn-success btn-sm me-2") }}
     {{ form.submit_send(id="submit-send", class="btn btn-primary btn-sm") }}
   </div>
 </form>
@@ -82,7 +82,8 @@ document.addEventListener('DOMContentLoaded', function () {
     sendField.name = 'submit_send';
     sendField.value = '1';
     form.appendChild(sendField);
-    form.submit();
+    modal.hide();
+    form.requestSubmit();
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- rename ZajeciaForm submit field to save to avoid DOM conflicts
- hide modal before calling requestSubmit to submit zajecia form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689368c386cc832a8c1ecf16d9ef835f