### PR TITLE
Clarify session type label and add help text

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -142,7 +142,7 @@ class UserSettingsForm(FlaskForm):
         'Domyślny czas trwania (min)',
         validators=[DataRequired(), NumberRange(min=1)],
     )
-    session_type = StringField('Rodzaj zajęć', validators=[Optional()])
+    session_type = StringField('Konsultacje z', validators=[Optional()])
     document_recipient_email = EmailField(
         'Email odbiorcy dokumentów',
         validators=[Optional(), Email()],

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -21,6 +21,7 @@
       <div class="mb-3">
         {{ form.session_type.label(class="form-label") }}
         {{ form.session_type(class="form-control") }}
+        <div class="form-text">Zwróć uwagę na poprawną odmianę wprowadzonego słowa.</div>
       </div>
       <div class="mb-3">
         {{ form.document_recipient_email.label(class="form-label") }}


### PR DESCRIPTION
## Summary
- rename `session_type` label to "Konsultacje z"
- show a help text below the `session_type` input in user settings

## Testing
- `flake8 app/forms.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936ae9b55c832ab1f77d1f1c4593f2