### PR TITLE
Persist recipient email in session form

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -205,13 +205,12 @@ def nowe_zajecia():
         db.session.commit()
 
         if form.submit_send.data:
-            recipient = (
-                current_user.document_recipient_email
-                or request.form.get("recipient_email")
-            )
+            recipient = request.form.get("recipient_email")
             if recipient and recipient != current_user.document_recipient_email:
                 current_user.document_recipient_email = recipient
                 db.session.commit()
+            if not recipient:
+                recipient = current_user.document_recipient_email
             if recipient:
                 output_dir = os.path.join(
                     current_app.root_path, "static", "docx"

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -61,7 +61,7 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-  const recipientEmail = "{{ current_user.document_recipient_email or '' }}";
+  let recipientEmail = "{{ current_user.document_recipient_email or '' }}";
   const submitSend = document.getElementById('submit-send');
   const form = document.getElementById('zajecia-form');
   const modalEl = document.getElementById('emailModal');
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('modal-submit').addEventListener('click', function () {
     const emailInput = document.getElementById('modal-email').value;
     document.getElementById('recipient-email').value = emailInput;
+    recipientEmail = emailInput;
     const sendField = document.createElement('input');
     sendField.type = 'hidden';
     sendField.name = 'submit_send';


### PR DESCRIPTION
## Summary
- store recipient email on send so later sessions reuse it
- update modal JS to remember email for subsequent sends

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689372a0c984832aa081a7548753b078