### PR TITLE
Insert specialist full name into DOCX reports

### DIFF
--- a/app/docx_generator.py
+++ b/app/docx_generator.py
@@ -45,12 +45,23 @@ def generate_docx(zajecia, beneficjenci, output_path):
                     for run in paragraph.runs:
                         run.text = run.text.replace("dietetykiem", zajecia.specjalista)
 
+    specialist_found = False
     for paragraph in doc.paragraphs:
         text = paragraph.text.strip()
         if text.startswith("Imię i nazwisko beneficjenta:"):
             paragraph.text = "Imię i nazwisko beneficjenta: " + names
         if text.startswith("Województwo:"):
             paragraph.text = "Województwo: " + wojew
+        if text.startswith("Imię i nazwisko specjalisty:"):
+            paragraph.text = (
+                "Imię i nazwisko specjalisty: " + zajecia.user.full_name
+            )
+            specialist_found = True
+
+    if not specialist_found:
+        doc.add_paragraph(
+            f"Imię i nazwisko specjalisty: {zajecia.user.full_name}"
+        )
 
     if doc.tables:
         table = doc.tables[0]

--- a/tests/test_docx_generator.py
+++ b/tests/test_docx_generator.py
@@ -24,7 +24,7 @@ def test_generate_docx_file_contains_text(app, tmp_path):
     """DOCX generated on disk should include rendered session data."""
 
     with app.app_context():
-        user = User(full_name="disk", email="disk@example.com")
+        user = User(full_name="Jan Kowalski", email="disk@example.com")
         user.set_password("pass")
         user.confirmed = True
         db.session.add(user)
@@ -36,7 +36,7 @@ def test_generate_docx_file_contains_text(app, tmp_path):
             data=date(2023, 3, 3),
             godzina_od=time(10, 0),
             godzina_do=time(11, 0),
-            specjalista="disk",
+            specjalista="psycholog",
             user_id=user.id,
         )
         zajecia.beneficjenci.append(benef)
@@ -47,7 +47,8 @@ def test_generate_docx_file_contains_text(app, tmp_path):
         generate_docx(zajecia, [benef], str(path))
         doc = Document(str(path))
         text = _docx_text(doc)
-        assert "disk" in text
+        assert zajecia.specjalista in text
+        assert user.full_name in text
         assert "Tomek" in text
         assert "dietetykiem" not in text
 


### PR DESCRIPTION
## Summary
- populate "Imię i nazwisko specjalisty" in generated DOCX using the session owner’s full name
- ensure fallback adds the specialist name paragraph when missing
- test DOCX generator for specialist and beneficiary names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937bfeff8c832a820cfc2673acffd0