### PR TITLE
Use DeleteForm helper in session list and add AJAX test

### DIFF
--- a/app/templates/_zajecia_rows.html
+++ b/app/templates/_zajecia_rows.html
@@ -13,10 +13,8 @@
       <i class="bi bi-pencil"></i>
     </a>
     <form method="post" action="{{ url_for('usun_zajecia', zajecia_id=zaj.id) }}" style="display:inline;">
-      {{ delete_form.csrf_token }}
-      <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń">
-        <i class="bi bi-trash"></i>
-      </button>
+      {{ delete_form.hidden_tag() }}
+      {{ delete_form.submit(class='btn btn-sm btn-danger', onclick="return confirm('Na pewno chcesz usunąć?')") }}
     </form>
   </td>
 </tr>

--- a/tests/test_zajecia_edit_delete.py
+++ b/tests/test_zajecia_edit_delete.py
@@ -92,6 +92,24 @@ def test_delete_session(app, client):
         assert db.session.get(Zajecia, z_id) is None
 
 
+def test_ajax_list_and_delete_session(app, client):
+    user_id = create_user(app)
+    login(client)
+    z_id, _ = create_session(app, user_id)
+
+    resp = client.get("/zajecia", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 200
+    text = resp.get_data(as_text=True)
+    assert f"/zajecia/{z_id}/usun" in text
+
+    resp = client.post(
+        f"/zajecia/{z_id}/usun", data={"submit": "1"}, follow_redirects=True
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert db.session.get(Zajecia, z_id) is None
+
+
 def test_cannot_edit_or_delete_foreign_session(app, client):
     owner_id = create_user(app, name="owner", email="owner@example.com")
     z_id, b_id = create_session(app, owner_id)


### PR DESCRIPTION
## Summary
- use `hidden_tag` and WTForms submit button for deleting sessions
- ensure session list view supplies `DeleteForm` for both full and AJAX renders
- test AJAX session listing and deletion

## Testing
- `pytest tests/test_zajecia_edit_delete.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689381072a44832a865c47522d00dd63