### PR TITLE
Add consultation specialist column and icons

### DIFF
--- a/app/templates/_zajecia_rows.html
+++ b/app/templates/_zajecia_rows.html
@@ -3,10 +3,15 @@
   <td>{{ zaj.data.strftime('%d.%m.%Y') }}</td>
   <td>{{ zaj.godzina_od.strftime('%H:%M') }} - {{ zaj.godzina_do.strftime('%H:%M') }}</td>
   <td>{{ zaj.specjalista }}</td>
+  <td>{{ zaj.user.full_name }}</td>
   <td>{{ 'wysłano' if zaj.doc_sent_at else 'niewysłano' }}</td>
   <td>
-    <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Pobierz raport</a>
-    <a href="{{ url_for('wyslij_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary">Wyślij ponownie</a>
+    <a href="{{ url_for('pobierz_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary" aria-label="Pobierz raport">
+      <i class="bi bi-download"></i>
+    </a>
+    <a href="{{ url_for('wyslij_docx', zajecia_id=zaj.id) }}" class="btn btn-sm btn-secondary" aria-label="Wyślij ponownie">
+      <i class="bi bi-envelope-arrow-up"></i>
+    </a>
   </td>
   <td>
     <a href="{{ url_for('edytuj_zajecia', zajecia_id=zaj.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj">
@@ -19,5 +24,5 @@
   </td>
 </tr>
 {% else %}
-<tr><td colspan="6">Brak zajęć.</td></tr>
+<tr><td colspan="7">Brak zajęć.</td></tr>
 {% endfor %}

--- a/app/templates/zajecia_list.html
+++ b/app/templates/zajecia_list.html
@@ -13,6 +13,7 @@
     <tr>
       <th>Data</th>
       <th>Godziny</th>
+      <th>Konsultacje z</th>
       <th>Specjalista</th>
       <th>Status</th>
       <th>Raporty</th>

--- a/tests/test_zajecia_edit_delete.py
+++ b/tests/test_zajecia_edit_delete.py
@@ -53,6 +53,12 @@ def test_session_list_shows_actions(app, client):
     text = resp.get_data(as_text=True)
     assert f"/zajecia/{z_id}/edytuj" in text
     assert f"/zajecia/{z_id}/usun" in text
+    assert "Konsultacje z" in text
+    assert "Specjalista" in text
+    assert "spec" in text
+    assert "user" in text
+    assert "bi bi-download" in text
+    assert "bi bi-envelope-arrow-up" in text
 
 
 def test_edit_session(app, client):


### PR DESCRIPTION
## Summary
- Show consultation type and specialist name in sessions list
- Replace report buttons with Bootstrap icons for download and resend
- Adjust tests for new column and icons

## Testing
- `pytest -q`
- `flake8` *(fails: line too long in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689383bacf58832abd7cf78c1368cc80