### PR TITLE
Cascade delete email logs when removing session

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -136,7 +136,7 @@ class SentEmail(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     zajecia_id = db.Column(
-        db.Integer, db.ForeignKey('zajecia.id'), nullable=False
+        db.Integer, db.ForeignKey('zajecia.id', ondelete='CASCADE'), nullable=False
     )
     recipient = db.Column(db.String(120), nullable=False)
     subject = db.Column(db.String(255), nullable=False)
@@ -144,4 +144,11 @@ class SentEmail(db.Model):
     status = db.Column(db.String(20), nullable=False)
     file_path = db.Column(db.String(255), nullable=True)
 
-    zajecia = db.relationship('Zajecia', backref='sent_emails')
+    zajecia = db.relationship(
+        'Zajecia',
+        backref=db.backref(
+            'sent_emails',
+            cascade='all, delete-orphan',
+            passive_deletes=True,
+        ),
+    )

--- a/migrations/versions/f9b94a4c8dc3_add_ondelete_cascade_to_sent_email.py
+++ b/migrations/versions/f9b94a4c8dc3_add_ondelete_cascade_to_sent_email.py
@@ -1,0 +1,37 @@
+"""add ondelete cascade to sent_email.zajecia_id
+
+Revision ID: f9b94a4c8dc3
+Revises: 11045d5514ab
+Create Date: 2025-10-08 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f9b94a4c8dc3'
+down_revision = '11045d5514ab'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('sent_email', recreate='always') as batch_op:
+        batch_op.create_foreign_key(
+            'sent_email_zajecia_id_fkey',
+            'zajecia',
+            ['zajecia_id'],
+            ['id'],
+            ondelete='CASCADE',
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('sent_email', recreate='always') as batch_op:
+        batch_op.create_foreign_key(
+            'sent_email_zajecia_id_fkey',
+            'zajecia',
+            ['zajecia_id'],
+            ['id'],
+        )

--- a/tests/test_sent_email_cascade_delete.py
+++ b/tests/test_sent_email_cascade_delete.py
@@ -1,0 +1,41 @@
+from datetime import date, time
+
+from sqlalchemy import text
+
+from app import db
+from app.models import User, Zajecia, SentEmail
+
+
+def test_deleting_session_removes_sent_emails(app):
+    with app.app_context():
+        db.session.execute(text("PRAGMA foreign_keys=ON"))
+        user = User(full_name="user", email="user@example.com")
+        user.set_password("secret")
+        user.confirmed = True
+        db.session.add(user)
+        db.session.commit()
+
+        session = Zajecia(
+            data=date(2023, 1, 1),
+            godzina_od=time(9, 0),
+            godzina_do=time(10, 0),
+            specjalista="spec",
+            user_id=user.id,
+        )
+        db.session.add(session)
+        db.session.commit()
+
+        email = SentEmail(
+            zajecia=session,
+            recipient="dest@example.com",
+            subject="hello",
+            status="sent",
+        )
+        db.session.add(email)
+        db.session.commit()
+
+        db.session.delete(session)
+        db.session.commit()
+
+        assert db.session.get(Zajecia, session.id) is None
+        assert SentEmail.query.count() == 0


### PR DESCRIPTION
## Summary
- ensure `SentEmail` rows delete when their `Zajecia` is removed by adding cascade/pk options
- add Alembic migration applying `ON DELETE CASCADE`
- test that removing a session clears its email logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689386f1dbcc832ab6894ef823fc4fea