### PR TITLE
Use instructor full name in DOCX specialist column

### DIFF
--- a/app/docx_generator.py
+++ b/app/docx_generator.py
@@ -30,7 +30,8 @@ def generate_docx(zajecia, beneficjenci, output_path):
         "time_range": f"{start_time} - {end_time}",
         "beneficjenci": names,
         "wojewodztwo": wojew,
-        "specjalista": zajecia.specjalista,
+        # full name of the instructor for later assertions/tests
+        "specjalista": zajecia.user.full_name,
     }
     current_app.config["_last_docx_context"] = context
 
@@ -68,7 +69,7 @@ def generate_docx(zajecia, beneficjenci, output_path):
         font_size = Pt(16)
         for idx, _ in enumerate(beneficjenci[:3]):
             row = table.rows[idx + 1]
-            values = [context["data"], context["time_range"], context["specjalista"]]
+            values = [context["data"], context["time_range"], zajecia.user.full_name]
             for cell, value in zip(row.cells[1:4], values):
                 cell.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
                 p = cell.paragraphs[0]

--- a/tests/test_docx_generator.py
+++ b/tests/test_docx_generator.py
@@ -51,6 +51,10 @@ def test_generate_docx_file_contains_text(app, tmp_path):
         assert user.full_name in text
         assert "Tomek" in text
         assert "dietetykiem" not in text
+        # The table column labeled "Imię i nazwisko specjalisty" should contain
+        # the instructor's full name for each listed session.
+        table = doc.tables[0]
+        assert table.rows[1].cells[3].text == user.full_name
 
         template = Document(os.path.join(app.root_path, "static", "wzor.docx"))
         assert "dietetykiem" in _docx_text(template)


### PR DESCRIPTION
## Summary
- Populate `Imię i nazwisko specjalisty` table column with the instructor's full name
- Verify generated DOCX inserts the instructor name in the specialist column

## Testing
- `pytest tests/test_docx_generator.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f83da88c4832abe076efec7395ace