### PR TITLE
Add Zajecia detail view and model import

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,7 @@
 from flask import render_template, redirect, url_for
 from app import app
 from app.forms import RegisterForm
+from app.models import Zajecia
 from app.utils import flash_success, flash_error, get_object_or_404, validate_form
 
 @app.route('/register', methods=['GET', 'POST'])
@@ -15,7 +16,6 @@ def register():
 @app.route('/zajecia/<int:zajecia_id>')
 def zajecia_detail(zajecia_id):
     zajecia = get_object_or_404(Zajecia, zajecia_id)
-    # ...existing code...
     return render_template('zajecia_detail.html', zajecia=zajecia)
 
 # Analogicznie używaj flash_success, flash_error, get_object_or_404, validate_form w innych widokach

--- a/tests/test_ui_features.py
+++ b/tests/test_ui_features.py
@@ -13,7 +13,10 @@ def test_flash_message_displayed(client, app):
 def test_login_form_placeholders(client):
     response = client.get('/login')
     assert b'placeholder="adres@email.pl"' in response.data
-    assert b'placeholder="Has\xc5\x82o"' in response.data or b'placeholder="Hasło"' in response.data
+    assert (
+        b'placeholder="Has\xc5\x82o"' in response.data
+        or 'placeholder="Hasło"'.encode() in response.data
+    )
 
 def test_dark_mode_toggle_button(client):
     response = client.get('/')
@@ -29,5 +32,12 @@ def test_settings_form_password_section(client, auth):
     # Zaloguj się i przejdź do ustawień
     auth.login()
     response = client.get('/settings')
-    assert b'Zmiana has\xc5\x82a' in response.data or b'Zmiana hasła' in response.data
-    assert b'placeholder="Obecne has\xc5\x82o"' in response.data or b'placeholder="Obecne hasło"' in response.data
+    assert (
+        b'Zmiana has\xc5\x82a' in response.data
+        or 'Zmiana hasła'.encode() in response.data
+    )
+    assert (
+        b'placeholder="Obecne has\xc5\x82o"' in response.data
+        or 'placeholder="Obecne hasło"'.encode() in response.data
+    )
+


### PR DESCRIPTION
## Summary
- import `Zajecia` in views module
- implement and simplify `zajecia_detail` view to fetch session by id
- fix UI test encoding of Polish strings

## Testing
- `pytest tests/test_ui_features.py::test_login_form_placeholders -q` *(fails: TemplateSyntaxError: unknown tag 'endblock')*

------
https://chatgpt.com/codex/tasks/task_e_689538d306d0832aa5cf1c1237599394