### PR TITLE
Stop storing DOCX context in app config

### DIFF
--- a/app/docx_generator.py
+++ b/app/docx_generator.py
@@ -36,7 +36,6 @@ def generate_docx(zajecia, beneficjenci, output_path):
         # full name of the instructor for later assertions/tests
         "specjalista": zajecia.user.full_name,
     }
-    current_app.config["_last_docx_context"] = context
 
     # Replace occurrences of "dietetykiem" throughout the document.
     for paragraph in doc.paragraphs:
@@ -82,3 +81,4 @@ def generate_docx(zajecia, beneficjenci, output_path):
                 p.alignment = WD_ALIGN_PARAGRAPH.CENTER
 
     doc.save(output_path)
+    return context


### PR DESCRIPTION
## Summary
- remove `_last_docx_context` from Flask config
- return context from `generate_docx`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68954a3345cc832a99657cd52c765c9e