### PR TITLE
refactor: extract helper for session docx emails

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,13 @@
-from flask import flash, abort
-from functools import wraps
+import os
+import re
+from datetime import datetime
+
+from flask import flash, abort, current_app
+from flask_mail import Message
+from smtplib import SMTPException
+
+from .docx_generator import generate_docx
+from . import mail
 
 def flash_success(message):
     flash(message, 'success')
@@ -20,3 +28,63 @@ def validate_form(form):
         for error in errors:
             flash(f"{getattr(form, field).label.text}: {error}", "danger")
     return False
+
+
+def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
+    """Generate a DOCX report for ``zajecia`` and send it via email.
+
+    Parameters
+    ----------
+    zajecia: Zajecia
+        Session for which the document should be generated.
+    recipient: str
+        Email address of the recipient.
+    subject: str, optional
+        Subject of the email. Defaults to ``"Raport zajęć"``.
+
+    Returns
+    -------
+    tuple[datetime | None, str]
+        A tuple containing the time the email was sent (``None`` on
+        failure) and a status string (``"sent"`` or ``"error"``).
+    """
+
+    output_dir = os.path.join(current_app.root_path, "static", "docx")
+    os.makedirs(output_dir, exist_ok=True)
+
+    beneficjenci = zajecia.beneficjenci
+    first_name = beneficjenci[0].imie if beneficjenci else "beneficjent"
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", first_name)
+    date_str = zajecia.data.strftime("%Y-%m-%d")
+    filename = f"Konsultacje z {zajecia.specjalista} {date_str} {safe_name}.docx"
+    output_path = os.path.join(output_dir, filename)
+
+    status = "error"
+    sent_at = None
+    try:
+        generate_docx(zajecia, beneficjenci, output_path)
+        msg = Message(
+            subject,
+            recipients=[recipient],
+            sender=current_app.config["MAIL_DEFAULT_SENDER"],
+        )
+        with open(output_path, "rb") as f:
+            msg.attach(
+                filename,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                f.read(),
+            )
+        mail.send(msg)
+        sent_at = datetime.utcnow()
+        status = "sent"
+    except (FileNotFoundError, SMTPException) as exc:
+        current_app.logger.error("Failed to send session document: %s", exc)
+    finally:
+        try:
+            os.remove(output_path)
+        except OSError:
+            current_app.logger.warning(
+                "Failed to remove generated DOCX %s", output_path
+            )
+
+    return sent_at, status


### PR DESCRIPTION
## Summary
- create `send_session_docx` helper to build, send and clean up DOCX session reports
- use the helper in routes to remove duplicated document/email logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68954d35e194832aaf42d6736ba0b01b