### PR TITLE
Validate password confirmation in settings

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -162,6 +162,19 @@ class UserSettingsForm(FlaskForm):
     )
     submit = SubmitField('Zapisz')
 
+    def validate(self, extra_validators=None):
+        """Ensure both password fields are provided together."""
+        rv = super().validate(extra_validators)
+        if self.new_password.data or self.confirm.data:
+            if not self.new_password.data or not self.confirm.data:
+                message = 'Oba pola hasła są wymagane'
+                if not self.new_password.data:
+                    self.new_password.errors.append(message)
+                if not self.confirm.data:
+                    self.confirm.errors.append(message)
+                rv = False
+        return rv
+
 
 class BeneficjentForm(FlaskForm):
     """Form for adding or editing a beneficiary."""

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -65,6 +65,48 @@ def test_settings_wrong_old_password(app, client):
     assert 'Nieprawidłowe aktualne hasło' in resp.get_data(as_text=True)
 
 
+def test_settings_password_change_missing_confirm(app, client):
+    create_user(app)
+    login(client)
+    resp = client.post(
+        '/settings',
+        data={
+            'email': 'c@example.com',
+            'full_name': 'change',
+            'default_duration': 90,
+            'old_password': 'old',
+            'new_password': 'new',
+        },
+        follow_redirects=True,
+    )
+    html = resp.get_data(as_text=True)
+    assert 'Oba pola hasła są wymagane' in html
+    with app.app_context():
+        user = User.query.filter_by(full_name='change').first()
+        assert user.check_password('old')
+
+
+def test_settings_password_change_missing_new_password(app, client):
+    create_user(app)
+    login(client)
+    resp = client.post(
+        '/settings',
+        data={
+            'email': 'c@example.com',
+            'full_name': 'change',
+            'default_duration': 90,
+            'old_password': 'old',
+            'confirm': 'new',
+        },
+        follow_redirects=True,
+    )
+    html = resp.get_data(as_text=True)
+    assert 'Oba pola hasła są wymagane' in html
+    with app.app_context():
+        user = User.query.filter_by(full_name='change').first()
+        assert user.check_password('old')
+
+
 def test_settings_form_prefilled_with_user_data(app, client):
     """GET /settings should render form fields populated with current user data."""
     create_user(app)


### PR DESCRIPTION
## Summary
- enforce that both `new_password` and `confirm` fields are provided together in user settings
- add tests for missing confirmation or new password

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954fac15f8832ab7a548bb0deecc35