### PR TITLE
Sanitize specialist name in session DOCX filenames

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -55,8 +55,9 @@ def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
     beneficjenci = zajecia.beneficjenci
     first_name = beneficjenci[0].imie if beneficjenci else "beneficjent"
     safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", first_name)
+    safe_specjalista = re.sub(r"[^A-Za-z0-9_.-]", "_", zajecia.specjalista)
     date_str = zajecia.data.strftime("%Y-%m-%d")
-    filename = f"Konsultacje z {zajecia.specjalista} {date_str} {safe_name}.docx"
+    filename = f"Konsultacje z {safe_specjalista} {date_str} {safe_name}.docx"
     output_path = os.path.join(output_dir, filename)
 
     status = "error"

--- a/tests/test_specjalista_filename_sanitization.py
+++ b/tests/test_specjalista_filename_sanitization.py
@@ -1,0 +1,32 @@
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+
+from flask import current_app
+
+from app.utils import send_session_docx
+
+
+def test_send_session_docx_sanitizes_specjalista(monkeypatch, app):
+    paths = {}
+
+    def fake_generate_docx(zajecia, beneficjenci, output_path):
+        paths['path'] = output_path
+        Path(output_path).write_bytes(b'dummy')
+
+    def fake_send(msg):
+        pass
+
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.mail.send', fake_send)
+
+    with app.app_context():
+        current_app.config['MAIL_DEFAULT_SENDER'] = 'sender@example.com'
+        zajecia = SimpleNamespace(
+            beneficjenci=[SimpleNamespace(imie='Ala')],
+            data=date(2023, 1, 1),
+            specjalista='Spec/Name',
+        )
+        send_session_docx(zajecia, 'dest@example.com')
+
+    assert paths['path'].endswith('Konsultacje z Spec_Name 2023-01-01 Ala.docx')


### PR DESCRIPTION
## Summary
- Sanitize `specjalista` value to eliminate unsafe characters before generating DOCX filenames
- Verify filename sanitization with a dedicated unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689552e39160832a9e22bcf3e2d8dd01