### PR TITLE
Handle trailing slash on login route

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -77,6 +77,7 @@ class LoginForm(FlaskForm):
     submit = SubmitField('Zaloguj się')
 
 
+@app.route('/login/', methods=['GET', 'POST'])
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     """Authenticate a user and redirect to the next page."""

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -6,7 +6,7 @@
 <p class="mb-4 text-muted">Podaj swój adres email i hasło, aby się zalogować.</p>
 <div class="row justify-content-center text-center">
   <div class="col-12 col-md-6 d-flex justify-content-center">
-    <form method="post" class="text-start w-100" style="max-width: 400px;">
+    <form method="post" action="{{ url_for('login') }}" class="text-start w-100" style="max-width: 400px;">
       {{ form.hidden_tag() }}
       {{ render_field(form.email, "adres@email.pl") }}
       {{ render_password_field(form.password, "Hasło", "current-password") }}


### PR DESCRIPTION
## Summary
- Allow `/login/` to be routed to the login view
- Ensure login form posts to correct login URL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d9192224832ab12bd086d947a200