### PR TITLE
Use in-memory DOCX generation and central filename helper

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,5 @@
-import os
 import re
+from io import BytesIO
 from datetime import datetime
 
 from flask import flash, abort, current_app
@@ -30,6 +30,22 @@ def validate_form(form):
     return False
 
 
+def build_docx_filename(zajecia):
+    """Build a safe DOCX filename for a given session."""
+
+    def sanitize(value):
+        return re.sub(r"[^A-Za-z0-9_.-]", "_", value)
+
+    beneficjenci = zajecia.beneficjenci
+    first_name = beneficjenci[0].imie if beneficjenci else "beneficjent"
+    date_str = zajecia.data.strftime("%Y-%m-%d")
+    return "Konsultacje z {} {} {}.docx".format(
+        sanitize(zajecia.specjalista),
+        date_str,
+        sanitize(first_name),
+    )
+
+
 def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
     """Generate a DOCX report for ``zajecia`` and send it via email.
 
@@ -49,43 +65,28 @@ def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
         failure) and a status string (``"sent"`` or ``"error"``).
     """
 
-    output_dir = os.path.join(current_app.root_path, "static", "docx")
-    os.makedirs(output_dir, exist_ok=True)
-
     beneficjenci = zajecia.beneficjenci
-    first_name = beneficjenci[0].imie if beneficjenci else "beneficjent"
-    safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", first_name)
-    safe_specjalista = re.sub(r"[^A-Za-z0-9_.-]", "_", zajecia.specjalista)
-    date_str = zajecia.data.strftime("%Y-%m-%d")
-    filename = f"Konsultacje z {safe_specjalista} {date_str} {safe_name}.docx"
-    output_path = os.path.join(output_dir, filename)
+    filename = build_docx_filename(zajecia)
 
     status = "error"
     sent_at = None
+    output = BytesIO()
     try:
-        generate_docx(zajecia, beneficjenci, output_path)
+        generate_docx(zajecia, beneficjenci, output)
         msg = Message(
             subject,
             recipients=[recipient],
             sender=current_app.config["MAIL_DEFAULT_SENDER"],
         )
-        with open(output_path, "rb") as f:
-            msg.attach(
-                filename,
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                f.read(),
-            )
+        msg.attach(
+            filename,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            output.getvalue(),
+        )
         mail.send(msg)
         sent_at = datetime.utcnow()
         status = "sent"
     except (FileNotFoundError, SMTPException) as exc:
         current_app.logger.error("Failed to send session document: %s", exc)
-    finally:
-        try:
-            os.remove(output_path)
-        except OSError:
-            current_app.logger.warning(
-                "Failed to remove generated DOCX %s", output_path
-            )
 
     return sent_at, status

--- a/tests/test_email_logs.py
+++ b/tests/test_email_logs.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from app import db
 from app.models import User, Beneficjent, SentEmail
 
@@ -42,11 +40,11 @@ def test_email_log_and_resend(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',

--- a/tests/test_send_docx_email.py
+++ b/tests/test_send_docx_email.py
@@ -42,11 +42,11 @@ def test_submit_send_dispatches_email_with_attachment(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',
@@ -93,11 +93,11 @@ def test_submit_send_with_invalid_email_shows_error(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',
@@ -132,11 +132,11 @@ def test_submit_send_shows_combined_message(monkeypatch, app, client):
     def fake_send(msg):
         pass
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',

--- a/tests/test_specjalista_default.py
+++ b/tests/test_specjalista_default.py
@@ -49,4 +49,4 @@ def test_specjalista_default_and_filename(app, client):
     resp = client.get(f"/zajecia/{z_id}/docx")
     assert resp.status_code == 200
     disposition = resp.headers.get("Content-Disposition", "")
-    assert "Konsultacje z Dr Who" in disposition
+    assert "Konsultacje z Dr_Who" in disposition

--- a/tests/test_specjalista_filename_sanitization.py
+++ b/tests/test_specjalista_filename_sanitization.py
@@ -1,5 +1,4 @@
 from datetime import date
-from pathlib import Path
 from types import SimpleNamespace
 
 from flask import current_app
@@ -8,14 +7,13 @@ from app.utils import send_session_docx
 
 
 def test_send_session_docx_sanitizes_specjalista(monkeypatch, app):
-    paths = {}
+    captured = {}
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        paths['path'] = output_path
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     def fake_send(msg):
-        pass
+        captured['filename'] = msg.attachments[0].filename
 
     monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
     monkeypatch.setattr('app.utils.mail.send', fake_send)
@@ -29,4 +27,4 @@ def test_send_session_docx_sanitizes_specjalista(monkeypatch, app):
         )
         send_session_docx(zajecia, 'dest@example.com')
 
-    assert paths['path'].endswith('Konsultacje z Spec_Name 2023-01-01 Ala.docx')
+    assert captured['filename'].endswith('Konsultacje z Spec_Name 2023-01-01 Ala.docx')


### PR DESCRIPTION
## Summary
- add `build_docx_filename` utility for sanitized DOCX names
- switch DOCX generation to in-memory streams for email sending and downloads
- drop duplicated filename sanitization logic from routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895eb8c5e94832aa5759889928c5430