### PR TITLE
Remove unused form validation helper and test error rendering

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -15,15 +15,6 @@ def flash_success(message):
 def flash_error(message):
     flash(message, 'danger')
 
-def validate_form(form):
-    if form.validate_on_submit():
-        return True
-    for field, errors in form.errors.items():
-        for error in errors:
-            flash(f"{getattr(form, field).label.text}: {error}", "danger")
-    return False
-
-
 def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
     """Generate a DOCX report for ``zajecia`` and send it via email.
 

--- a/tests/test_form_errors.py
+++ b/tests/test_form_errors.py
@@ -1,0 +1,24 @@
+import re
+
+def test_register_required_field_errors(client):
+    response = client.post('/register', data={}, follow_redirects=True)
+    text = response.get_data(as_text=True)
+    errors = re.findall(r'<div class="text-danger">(.*?)</div>', text)
+    # Expect four required field errors: full_name, email, password, confirm
+    assert errors.count('This field is required.') >= 4
+
+
+def test_register_password_mismatch_error(client):
+    response = client.post(
+        '/register',
+        data={
+            'full_name': 'user',
+            'email': 'user@example.com',
+            'password': 'secret',
+            'confirm': 'different',
+        },
+        follow_redirects=True,
+    )
+    text = response.get_data(as_text=True)
+    errors = re.findall(r'<div class="text-danger">(.*?)</div>', text)
+    assert 'Hasła muszą się zgadzać' in errors


### PR DESCRIPTION
## Summary
- drop `validate_form` helper in favor of `form.validate_on_submit`
- ensure form field errors render via `_form_macros.html`
- add regression tests verifying registration errors appear next to fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f5815d8c832ab6aa50ea0dcfea39