### PR TITLE
Refactor dark mode to static files

### DIFF
--- a/app/static/dark_mode.js
+++ b/app/static/dark_mode.js
@@ -1,0 +1,34 @@
+// Dark mode toggle with persistence
+function applyDarkMode(isDark) {
+  const body = document.body;
+  const icon = document.getElementById('darkModeToggle').querySelector('i');
+  if (isDark) {
+    body.classList.add('dark-mode');
+    icon.classList.remove('bi-moon');
+    icon.classList.add('bi-sun');
+  } else {
+    body.classList.remove('dark-mode');
+    icon.classList.remove('bi-sun');
+    icon.classList.add('bi-moon');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  const darkModeBtn = document.getElementById('darkModeToggle');
+  const savedMode = localStorage.getItem('darkMode');
+  applyDarkMode(savedMode === 'enabled');
+
+  darkModeBtn.addEventListener('click', function () {
+    const isDark = document.body.classList.toggle('dark-mode');
+    const icon = darkModeBtn.querySelector('i');
+    if (isDark) {
+      icon.classList.remove('bi-moon');
+      icon.classList.add('bi-sun');
+      localStorage.setItem('darkMode', 'enabled');
+    } else {
+      icon.classList.remove('bi-sun');
+      icon.classList.add('bi-moon');
+      localStorage.setItem('darkMode', 'disabled');
+    }
+  });
+});

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -11,3 +11,42 @@
     opacity: 0.85;
 }
 
+/* Sticky header for tables */
+.table thead th {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 2;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #181a1b !important;
+    color: #f8f9fa !important;
+}
+
+body.dark-mode .bg-white,
+body.dark-mode .table,
+body.dark-mode .table thead th {
+    background-color: #23272b !important;
+    color: #f8f9fa !important;
+}
+
+body.dark-mode .bg-dark {
+    background-color: #181a1b !important;
+}
+
+body.dark-mode .navbar,
+body.dark-mode .offcanvas,
+body.dark-mode .dropdown-menu {
+    background-color: #23272b !important;
+    color: #f8f9fa !important;
+}
+
+body.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #23272b !important;
+}
+
+body.dark-mode .table-hover > tbody > tr:hover {
+    background-color: #343a40 !important;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,37 +7,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-  <style>
-    /* Sticky header for tables */
-    .table thead th {
-      position: sticky;
-      top: 0;
-      background: #fff;
-      z-index: 2;
-    }
-    /* Dark mode styles */
-    body.dark-mode {
-      background-color: #181a1b !important;
-      color: #f8f9fa !important;
-    }
-    body.dark-mode .bg-white, body.dark-mode .table, body.dark-mode .table thead th {
-      background-color: #23272b !important;
-      color: #f8f9fa !important;
-    }
-    body.dark-mode .bg-dark {
-      background-color: #181a1b !important;
-    }
-    body.dark-mode .navbar, body.dark-mode .offcanvas, body.dark-mode .dropdown-menu {
-      background-color: #23272b !important;
-      color: #f8f9fa !important;
-    }
-    body.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
-      background-color: #23272b !important;
-    }
-    body.dark-mode .table-hover > tbody > tr:hover {
-      background-color: #343a40 !important;
-    }
-  </style>
 </head>
 <body class="bg-light text-dark pb-5">
   {% from '_nav_macros.html' import render_nav_items, render_user_items with context %}
@@ -109,6 +78,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='dropdown_search.js') }}"></script>
   <script src="{{ url_for('static', filename='live_search.js') }}"></script>
+  <script src="{{ url_for('static', filename='dark_mode.js') }}"></script>
   <script>
     // Loader show/hide helpers
     function showLoader() {
@@ -123,20 +93,6 @@
           showLoader();
         });
       });
-      // Dark mode toggle
-      const darkModeBtn = document.getElementById('darkModeToggle');
-      darkModeBtn.addEventListener('click', function() {
-        document.body.classList.toggle('dark-mode');
-        const icon = darkModeBtn.querySelector('i');
-        if(document.body.classList.contains('dark-mode')) {
-          icon.classList.remove('bi-moon');
-          icon.classList.add('bi-sun');
-        } else {
-          icon.classList.remove('bi-sun');
-          icon.classList.add('bi-moon');
-        }
-      });
-
       // Password visibility toggles
       document.querySelectorAll('.toggle-password').forEach(function(icon) {
         icon.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- move table header and dark theme CSS into styles.css
- add dark_mode.js with localStorage-based toggle
- clean base template to load external style and script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895fa3892a4832a81e197670ef4b2fb