### PR TITLE
Use Enum for roles and add repr methods

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,9 +6,10 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from . import login_manager
 from itsdangerous import URLSafeTimedSerializer
 from flask import current_app
+import enum
 
 
-class Roles:
+class Roles(enum.Enum):
     """Enumeration of user roles available in the system."""
 
     ADMIN = "admin"
@@ -24,7 +25,7 @@ class User(UserMixin, db.Model):
     document_recipient_email = db.Column(db.String(120), nullable=True)
     password_hash = db.Column(db.String(128))
     default_duration = db.Column(db.Integer, default=90)
-    role = db.Column(db.String(20), default=Roles.INSTRUCTOR)
+    role = db.Column(db.Enum(Roles), default=Roles.INSTRUCTOR)
     confirmed = db.Column(db.Boolean, default=False)
     session_type = db.Column(db.String(100))
 
@@ -66,6 +67,9 @@ class User(UserMixin, db.Model):
             return None
         return db.session.get(User, data.get('user_id'))
 
+    def __repr__(self):
+        return f"<User {self.id} {self.full_name} ({self.role.value})>"
+
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -84,6 +88,9 @@ class Beneficjent(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     user = db.relationship('User')
 
+    def __repr__(self):
+        return f"<Beneficjent {self.id} {self.imie}>"
+
 
 class Zajecia(db.Model):
     """Scheduled consultation session with related beneficiaries."""
@@ -101,6 +108,9 @@ class Zajecia(db.Model):
     beneficjenci = db.relationship(
         'Beneficjent', secondary='zajecia_beneficjenci'
     )
+
+    def __repr__(self):
+        return f"<Zajecia {self.id} {self.data} {self.specjalista}>"
 
 
 # Tabela relacyjna: wielu beneficjentów na zajęciach
@@ -152,3 +162,6 @@ class SentEmail(db.Model):
             passive_deletes=True,
         ),
     )
+
+    def __repr__(self):
+        return f"<SentEmail {self.id} to {self.recipient} status={self.status}>"

--- a/app/templates/_nav_macros.html
+++ b/app/templates/_nav_macros.html
@@ -11,7 +11,7 @@
   <li class="nav-item">
     <a class="nav-link{% if request.endpoint == 'sessions.lista_beneficjentow' %} active{% endif %}" href="{{ url_for('sessions.lista_beneficjentow') }}"{% if request.endpoint == 'sessions.lista_beneficjentow' %} aria-current="page"{% endif %}>Beneficjenci</a>
   </li>
-  {% if current_user.is_authenticated and current_user.role == 'admin' %}
+  {% if current_user.is_authenticated and current_user.role.value == 'admin' %}
   {% set admin_endpoints = ['admin.admin_instruktorzy', 'admin.admin_beneficjenci', 'admin.admin_zajecia', 'admin.admin_ustawienia'] %}
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle{% if request.endpoint in admin_endpoints %} active{% endif %}" href="#" id="{{ admin_id }}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{% if request.endpoint in admin_endpoints %} aria-current="page"{% endif %}>Admin</a>

--- a/migrations/versions/8bd82fd7018c_change_user_role_to_enum.py
+++ b/migrations/versions/8bd82fd7018c_change_user_role_to_enum.py
@@ -1,0 +1,35 @@
+"""Change user.role column to Enum."""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8bd82fd7018c'
+down_revision = 'f9b94a4c8dc3'
+branch_labels = None
+depends_on = None
+
+
+roles_enum = sa.Enum('admin', 'instructor', name='roles')
+
+
+def upgrade():
+    roles_enum.create(op.get_bind(), checkfirst=True)
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column(
+            'role',
+            existing_type=sa.String(length=20),
+            type_=roles_enum,
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column(
+            'role',
+            existing_type=roles_enum,
+            type_=sa.String(length=20),
+            existing_nullable=True,
+        )
+    roles_enum.drop(op.get_bind(), checkfirst=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ import pytest
 from smtplib import SMTPException
 
 from app import create_app, db
-from app.models import User
+from app.models import User, Roles
 
 DB_PATH = os.path.join(
     os.path.dirname(__file__),
@@ -69,7 +69,7 @@ def test_admin_created_from_env(monkeypatch):
         assert admin is not None
         assert admin.email == 'admin@example.com'
         assert admin.check_password('adminpass')
-        assert admin.role == 'admin'
+        assert admin.role == Roles.ADMIN
         assert admin.confirmed
 
     # create_app called again should not alter admin confirmation status

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -10,7 +10,7 @@ def create_users(app):
         admin = User(
             full_name='admin',
             email='admin@example.com',
-            role='admin',
+            role=Roles.ADMIN,
         )
         admin.set_password('pass')
         admin.confirmed = True


### PR DESCRIPTION
## Summary
- replace string-based role handling with enum.Enum
- add __repr__ methods for User, Beneficjent, Zajecia, and SentEmail
- migrate user.role column to Enum

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895fc0176e8832a862ea72be1142bf6