### PR TITLE
Use in-memory DOCX generation and sanitize filenames

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import io
 from datetime import datetime
 
 from flask import flash, current_app
@@ -58,62 +59,37 @@ def send_email(subject, recipients, body, attachments=None):
         current_app.logger.error("Failed to send email: %s", exc)
     return sent_at, status
 
-def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
-    """Generate a DOCX report for ``zajecia`` and send it via email.
 
-    Parameters
-    ----------
-    zajecia: Zajecia
-        Session for which the document should be generated.
-    recipient: str
-        Email address of the recipient.
-    subject: str, optional
-        Subject of the email. Defaults to ``"Raport zajęć"``.
-
-    Returns
-    -------
-    tuple[datetime | None, str]
-        A tuple containing the time the email was sent (``None`` on
-        failure) and a status string (``"sent"`` or ``"error"``).
-    """
-
-    output_dir = os.path.join(current_app.root_path, "static", "docx")
-    os.makedirs(output_dir, exist_ok=True)
+def build_docx_filename(zajecia):
+    """Return a sanitized filename for the DOCX report of ``zajecia``."""
 
     beneficjenci = zajecia.beneficjenci
     first_name = beneficjenci[0].imie if beneficjenci else "beneficjent"
     safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", first_name)
     safe_specjalista = re.sub(r"[^A-Za-z0-9_.-]", "_", zajecia.specjalista)
     date_str = zajecia.data.strftime("%Y-%m-%d")
-    filename = f"Konsultacje z {safe_specjalista} {date_str} {safe_name}.docx"
-    output_path = os.path.join(output_dir, filename)
+    return f"Konsultacje z {safe_specjalista} {date_str} {safe_name}.docx"
 
-    status = "error"
-    sent_at = None
+
+def send_session_docx(zajecia, recipient, subject="Raport zajęć"):
+    """Generate a DOCX report for ``zajecia`` and send it via email."""
+
+    beneficjenci = zajecia.beneficjenci
+    filename = build_docx_filename(zajecia)
+
+    buffer = io.BytesIO()
     try:
-        generate_docx(zajecia, beneficjenci, output_path)
-        msg = Message(
-            subject,
-            recipients=[recipient],
-            sender=current_app.config["MAIL_DEFAULT_SENDER"],
-        )
-        with open(output_path, "rb") as f:
-            msg.attach(
-                filename,
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                f.read(),
-            )
-        mail.send(msg)
-        sent_at = datetime.utcnow()
-        status = "sent"
-    except (FileNotFoundError, SMTPException) as exc:
-        current_app.logger.error("Failed to send session document: %s", exc)
-    finally:
-        try:
-            os.remove(output_path)
-        except OSError:
-            current_app.logger.warning(
-                "Failed to remove generated DOCX %s", output_path
-            )
+        generate_docx(zajecia, beneficjenci, buffer)
+    except FileNotFoundError as exc:
+        current_app.logger.error("Failed to generate session document: %s", exc)
+        return None, "error"
 
-    return sent_at, status
+    attachments = [
+        (
+            filename,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            buffer.getvalue(),
+        )
+    ]
+
+    return send_email(subject, [recipient], "", attachments=attachments)

--- a/tests/test_email_logs.py
+++ b/tests/test_email_logs.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from app import db
 from app.models import User, Beneficjent, SentEmail
 
@@ -42,11 +40,11 @@ def test_email_log_and_resend(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',

--- a/tests/test_send_docx_email.py
+++ b/tests/test_send_docx_email.py
@@ -42,11 +42,11 @@ def test_submit_send_dispatches_email_with_attachment(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',
@@ -93,11 +93,11 @@ def test_submit_send_with_invalid_email_shows_error(monkeypatch, app, client):
     def fake_send(msg):
         messages.append(msg)
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',
@@ -132,11 +132,11 @@ def test_submit_send_shows_combined_message(monkeypatch, app, client):
     def fake_send(msg):
         pass
 
-    def fake_generate_docx(zajecia, beneficjenci, output_path):
-        Path(output_path).write_bytes(b'dummy')
+    def fake_generate_docx(zajecia, beneficjenci, output):
+        output.write(b'dummy')
 
     monkeypatch.setattr('app.routes.mail.send', fake_send)
-    monkeypatch.setattr('app.routes.generate_docx', fake_generate_docx)
+    monkeypatch.setattr('app.utils.generate_docx', fake_generate_docx)
 
     resp = client.post(
         '/zajecia/nowe',

--- a/tests/test_specjalista_default.py
+++ b/tests/test_specjalista_default.py
@@ -49,4 +49,4 @@ def test_specjalista_default_and_filename(app, client):
     resp = client.get(f"/zajecia/{z_id}/docx")
     assert resp.status_code == 200
     disposition = resp.headers.get("Content-Disposition", "")
-    assert "Konsultacje z Dr Who" in disposition
+    assert "Konsultacje z Dr_Who" in disposition


### PR DESCRIPTION
## Summary
- Add `build_docx_filename` for sanitized report names.
- Generate DOCX files in-memory and send via `send_email`.
- Stream DOCX downloads from memory without temporary files.
- Update tests to validate in-memory generation and filename sanitization.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960ec1bf08832a9c9910bbeb05bfe9