### PR TITLE
Add HTML registration email template and support

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -90,8 +90,11 @@ def register():
                 f"Użytkownik {user.full_name} zarejestrował się z adresem "
                 f"{user.email}. Potwierdź konto: {confirm_url}"
             )
+            html_body = render_template(
+                "email/new_registration.html", confirm_url=confirm_url
+            )
             _, status = send_email(
-                "Nowa rejestracja użytkownika", [admin_email], body
+                "Nowa rejestracja użytkownika", [admin_email], body, html_body=html_body
             )
             if status == "error":
                 flash("Nie udało się wysłać powiadomienia do administratora.")

--- a/app/templates/email/new_registration.html
+++ b/app/templates/email/new_registration.html
@@ -1,0 +1,4 @@
+<p>Użytkownik zarejestrował się w systemie.</p>
+<p>
+  <a href="{{ confirm_url }}" style="display:inline-block;padding:10px 20px;background-color:#0d6efd;color:#ffffff;text-decoration:none;border-radius:4px;">Potwierdź konto</a>
+</p>

--- a/app/utils.py
+++ b/app/utils.py
@@ -17,7 +17,7 @@ def flash_error(message):
     flash(message, 'danger')
 
 
-def send_email(subject, recipients, body, attachments=None):
+def send_email(subject, recipients, body, attachments=None, html_body=None):
     """Send an email using the configured Flask-Mail extension.
 
     Parameters
@@ -31,6 +31,9 @@ def send_email(subject, recipients, body, attachments=None):
     attachments: iterable[tuple[str, str, bytes]], optional
         Iterable of ``(filename, content_type, data)`` tuples representing
         attachments to include in the message.
+    html_body: str, optional
+        HTML body of the message. If provided, the email will contain both a
+        plain text and HTML version.
 
     Returns
     -------
@@ -45,6 +48,8 @@ def send_email(subject, recipients, body, attachments=None):
         sender=current_app.config["MAIL_DEFAULT_SENDER"],
     )
     msg.body = body
+    if html_body is not None:
+        msg.html = html_body
     if attachments:
         for filename, content_type, data in attachments:
             msg.attach(filename, content_type, data)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -199,6 +199,8 @@ def test_register_sends_confirmation_email(monkeypatch, client, app):
         user = User.query.filter_by(full_name='jan').first()
         assert user is not None
         assert f'/admin/instruktorzy/{user.id}/confirm' in msg.body
+        assert f'/admin/instruktorzy/{user.id}/confirm' in msg.html
+        assert '<a ' in msg.html and 'style=' in msg.html
 
 
 def test_password_reset_flow(monkeypatch, app):


### PR DESCRIPTION
## Summary
- allow send_email to include optional HTML body
- send registration email using HTML template with confirm button
- test for HTML link in registration email

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962acd4b38832aa6b7c9ad744aab20