### PR TITLE
Replace SentEmail query.get with session.get

### DIFF
--- a/tests/test_email_logs.py
+++ b/tests/test_email_logs.py
@@ -77,7 +77,7 @@ def test_email_log_and_resend(monkeypatch, app, client):
     assert len(messages) == 2
 
     with app.app_context():
-        log = SentEmail.query.get(email_id)
+        log = db.session.get(SentEmail, email_id)
         assert log.status == 'sent'
         assert log.sent_at != first_sent_at
 


### PR DESCRIPTION
## Summary
- use SQLAlchemy 2.0 style Session.get for fetching email logs

## Testing
- `pytest tests/test_email_logs.py::test_email_log_and_resend -q`


------
https://chatgpt.com/codex/tasks/task_e_68962f38d42c832a8ecde1884ad6be9d