### PR TITLE
Fix pydocstyle config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [pydocstyle]
-match-dir=(?!migrations).*\
+match-dir=(?!migrations).*
+match = (?!migrations).*
+


### PR DESCRIPTION
## Summary
- fix match-dir for pydocstyle
- add match rule excluding migrations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689631d888ac832aa588d6674659904e