### PR TITLE
refactor: use migrate db engine directly

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,21 +15,12 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
 
-def get_engine():
-    try:
-        # this works with Flask-SQLAlchemy<3 and Alchemical
-        return current_app.extensions['migrate'].db.get_engine()
-    except (TypeError, AttributeError):
-        # this works with Flask-SQLAlchemy>=3
-        return current_app.extensions['migrate'].db.engine
-
-
 def get_engine_url():
+    engine = current_app.extensions['migrate'].db.engine
     try:
-        return get_engine().url.render_as_string(hide_password=False).replace(
-            '%', '%%')
+        return engine.url.render_as_string(hide_password=False).replace('%', '%%')
     except AttributeError:
-        return str(get_engine().url).replace('%', '%%')
+        return str(engine.url).replace('%', '%%')
 
 
 # add your model's MetaData object here
@@ -94,7 +85,7 @@ def run_migrations_online():
     if conf_args.get("process_revision_directives") is None:
         conf_args["process_revision_directives"] = process_revision_directives
 
-    connectable = get_engine()
+    connectable = current_app.extensions['migrate'].db.engine
 
     with connectable.connect() as connection:
         context.configure(


### PR DESCRIPTION
## Summary
- remove Alembic `get_engine` helper
- reference `current_app.extensions['migrate'].db.engine` directly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963e83a7c8832aa36f73ac24925d3e