### PR TITLE
Use SQLAlchemy select in email log test

### DIFF
--- a/tests/test_email_logs.py
+++ b/tests/test_email_logs.py
@@ -1,3 +1,5 @@
+from sqlalchemy import select
+
 from app import db
 from app.models import User, Beneficjent, SentEmail
 
@@ -62,7 +64,7 @@ def test_email_log_and_resend(monkeypatch, app, client):
     assert len(messages) == 1
 
     with app.app_context():
-        log = SentEmail.query.one()
+        log = db.session.execute(select(SentEmail)).scalar_one()
         assert log.recipient == 'dest@example.com'
         assert log.status == 'sent'
         first_sent_at = log.sent_at
@@ -80,4 +82,3 @@ def test_email_log_and_resend(monkeypatch, app, client):
         log = db.session.get(SentEmail, email_id)
         assert log.status == 'sent'
         assert log.sent_at != first_sent_at
-


### PR DESCRIPTION
## Summary
- use SQLAlchemy `select` with `db.session.execute(...).scalar_one()` to fetch email log
- add `select` import in email log test

## Testing
- `flake8 tests/test_email_logs.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689645aee824832aaa43101ff3cff238