### PR TITLE
Add tests for send_email utility

### DIFF
--- a/tests/test_utils_send_email.py
+++ b/tests/test_utils_send_email.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from smtplib import SMTPException
+
+from app.utils import send_email
+
+
+def test_send_email_with_attachment(monkeypatch, app):
+    """send_email returns timestamp and 'sent' status with an attachment."""
+    def fake_send(message):
+        return None
+
+    monkeypatch.setattr("app.utils.mail.send", fake_send)
+
+    with app.app_context():
+        sent_at, status = send_email(
+            "Subject",
+            ["dest@example.com"],
+            "Body",
+            attachments=[("file.txt", "text/plain", b"data")],
+        )
+
+    assert status == "sent"
+    assert isinstance(sent_at, datetime)
+
+
+def test_send_email_handles_smtp_exception(monkeypatch, app):
+    """send_email returns error status and no timestamp when sending fails."""
+    def fake_send(message):
+        raise SMTPException("fail")
+
+    monkeypatch.setattr("app.utils.mail.send", fake_send)
+
+    with app.app_context():
+        sent_at, status = send_email(
+            "Subject",
+            ["dest@example.com"],
+            "Body",
+        )
+
+    assert status == "error"
+    assert sent_at is None


### PR DESCRIPTION
## Summary
- add tests for send_email to validate success with attachments
- add test for SMTPException resulting in error status

## Testing
- `flake8 tests/test_utils_send_email.py`
- `pytest tests/test_utils_send_email.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68966bea23dc832a9109e7dac5ce47e9