### PR TITLE
Normalize user role enum values to uppercase

### DIFF
--- a/migrations/versions/8bd82fd7018c_change_user_role_to_enum.py
+++ b/migrations/versions/8bd82fd7018c_change_user_role_to_enum.py
@@ -10,11 +10,12 @@ branch_labels = None
 depends_on = None
 
 
-roles_enum = sa.Enum('admin', 'instructor', name='roles')
+roles_enum = sa.Enum('ADMIN', 'INSTRUCTOR', name='roles')
 
 
 def upgrade():
     roles_enum.create(op.get_bind(), checkfirst=True)
+    op.execute("UPDATE user SET role = UPPER(role)")
     with op.batch_alter_table('user', schema=None) as batch_op:
         batch_op.alter_column(
             'role',


### PR DESCRIPTION
## Summary
- ensure migration upgrades user.role to uppercase Enum values

## Testing
- `SECRET_KEY=test FLASK_APP=run.py flask db upgrade`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68966dbf305c832a931f5d56f4884126