### PR TITLE
Store user role enum values

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -25,7 +25,10 @@ class User(UserMixin, db.Model):
     document_recipient_email = db.Column(db.String(120), nullable=True)
     password_hash = db.Column(db.String(128))
     default_duration = db.Column(db.Integer, default=90)
-    role = db.Column(db.Enum(Roles), default=Roles.INSTRUCTOR)
+    role = db.Column(
+        db.Enum(Roles, values_callable=lambda e: [r.value for r in e]),
+        default=Roles.INSTRUCTOR,
+    )
     confirmed = db.Column(db.Boolean, default=False)
     session_type = db.Column(db.String(100))
 

--- a/migrations/versions/c35bb5940733_store_role_values.py
+++ b/migrations/versions/c35bb5940733_store_role_values.py
@@ -1,0 +1,56 @@
+"""store role values
+
+Revision ID: c35bb5940733
+Revises: 8bd82fd7018c
+Create Date: 2025-08-08 21:48:55.806023
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c35bb5940733'
+down_revision = '8bd82fd7018c'
+branch_labels = None
+depends_on = None
+
+
+old_roles = sa.Enum("ADMIN", "INSTRUCTOR", name="roles")
+new_roles = sa.Enum("admin", "instructor", name="roles")
+
+
+def upgrade():
+    """Switch user.role to store enum values instead of names."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE roles RENAME TO roles_old")
+        new_roles.create(bind)
+        op.execute(
+            'ALTER TABLE "user" ALTER COLUMN role TYPE roles USING LOWER(role)::text::roles'
+        )
+        op.execute("DROP TYPE roles_old")
+    else:
+        op.execute("UPDATE user SET role = LOWER(role)")
+        with op.batch_alter_table("user", schema=None) as batch_op:
+            batch_op.alter_column(
+                "role", existing_type=old_roles, type_=new_roles, existing_nullable=True
+            )
+
+
+def downgrade():
+    """Revert user.role to store enum names."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE roles RENAME TO roles_old")
+        old_roles.create(bind)
+        op.execute(
+            'ALTER TABLE "user" ALTER COLUMN role TYPE roles USING UPPER(role)::text::roles'
+        )
+        op.execute("DROP TYPE roles_old")
+    else:
+        op.execute("UPDATE user SET role = UPPER(role)")
+        with op.batch_alter_table("user", schema=None) as batch_op:
+            batch_op.alter_column(
+                "role", existing_type=new_roles, type_=old_roles, existing_nullable=True
+            )


### PR DESCRIPTION
## Summary
- store enum values for `User.role`
- migrate existing `user.role` entries to new enum values

## Testing
- `flask --app run.py db upgrade`
- `python - <<'PY'\nfrom app import create_app\napp=create_app()\nprint('app ok')\nPY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896702edbb8832abc3cb1b5ddc1a627