### PR TITLE
Handle missing beneficiaries in session form

### DIFF
--- a/app/sessions/routes.py
+++ b/app/sessions/routes.py
@@ -59,6 +59,9 @@ def nowe_zajecia():
         .all()
     ]
 
+    if not form.beneficjenci.choices:
+        flash("Brak beneficjentów. Dodaj nowego, aby utworzyć zajęcia.")
+
     if request.method == "GET":
         tz = pytz.timezone(current_app.config["TIMEZONE"])
         now = datetime.now(tz)
@@ -72,7 +75,7 @@ def nowe_zajecia():
         ).time()
         form.specjalista.data = current_user.session_type
 
-    if form.validate_on_submit():
+    if form.validate_on_submit() and form.beneficjenci.choices:
         zajecia = Zajecia(
             data=form.data.data,
             godzina_od=form.godzina_od.data,

--- a/app/templates/zajecia_form.html
+++ b/app/templates/zajecia_form.html
@@ -12,14 +12,17 @@
     {{ render_field(form.godzina_od, "Godzina rozpoczęcia") }}
     {{ render_field(form.godzina_do, "Godzina zakończenia") }}
     {{ render_field(form.specjalista, "Specjalista") }}
-    {{ render_field(form.beneficjenci) }}
-    {% if form.beneficjenci.choices|length == 0 %}
-      <p>Brak beneficjentów. <a href="{{ url_for('sessions.nowy_beneficjent') }}">Dodaj nowego</a></p>
+    {% if form.beneficjenci.choices %}
+        {{ render_field(form.beneficjenci) }}
+    {% else %}
+        <p>Brak beneficjentów. <a href="{{ url_for('sessions.nowy_beneficjent') }}">Dodaj nowego</a></p>
     {% endif %}
+    {% if form.beneficjenci.choices %}
     <div class="text-center mt-4">
       {{ form.save(class="btn btn-success btn-lg me-2 px-4") }}
       {{ form.submit_send(id="submit-send", class="btn btn-primary btn-lg px-4") }}
     </div>
+    {% endif %}
   </form>
 </div>
 


### PR DESCRIPTION
## Summary
- Show beneficiary field only when options exist and hide action buttons otherwise
- Flash notice when no beneficiaries are available and avoid processing submissions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68968409d164832a887238f4160599fb