### PR TITLE
Przebudowa widoku admina użytkowników

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -161,29 +161,31 @@ def admin_usun_zajecia(zajecia_id):
     return redirect(url_for("admin.admin_zajecia"))
 
 
-@admin_bp.route("/instruktorzy")
+@admin_bp.route("/uzytkownicy")
 @login_required
 @admin_required
-def admin_instruktorzy():
-    """List all instructor accounts."""
+def admin_uzytkownicy():
+    """List all instructor and admin accounts."""
     instructors = User.query.filter_by(role=Roles.INSTRUCTOR).all()
+    admins = User.query.filter_by(role=Roles.ADMIN).all()
     delete_form = DeleteForm()
     promote_form = PromoteForm()
     confirm_form = ConfirmForm()
     return render_template(
-        "admin/instructors_list.html",
+        "admin/users_list.html",
         instructors=instructors,
+        admins=admins,
         delete_form=delete_form,
         promote_form=promote_form,
         confirm_form=confirm_form,
     )
 
 
-@admin_bp.route("/instruktorzy/<int:user_id>/edytuj", methods=["GET", "POST"])
+@admin_bp.route("/uzytkownicy/<int:user_id>/edytuj", methods=["GET", "POST"])
 @login_required
 @admin_required
-def admin_edytuj_instruktora(user_id):
-    """Admin view for editing an instructor account."""
+def admin_edytuj_uzytkownika(user_id):
+    """Admin view for editing a user account."""
     instr = db.session.get(User, user_id)
     if instr is None:
         abort(404)
@@ -192,18 +194,18 @@ def admin_edytuj_instruktora(user_id):
         instr.full_name = form.full_name.data
         instr.email = form.email.data
         db.session.commit()
-        flash("Instruktor zaktualizowany.")
-        return redirect(url_for("admin.admin_instruktorzy"))
+        flash("Użytkownik zaktualizowany.")
+        return redirect(url_for("admin.admin_uzytkownicy"))
     return render_template(
-        "instructor_form.html", form=form, title="Edytuj instruktora"
+        "instructor_form.html", form=form, title="Edytuj użytkownika"
     )
 
 
-@admin_bp.route("/instruktorzy/<int:user_id>/usun", methods=["POST"])
+@admin_bp.route("/uzytkownicy/<int:user_id>/usun", methods=["POST"])
 @login_required
 @admin_required
-def admin_usun_instruktora(user_id):
-    """Admin action to delete an instructor."""
+def admin_usun_uzytkownika(user_id):
+    """Admin action to delete a user."""
     form = DeleteForm()
     if form.validate_on_submit():
         instr = db.session.get(User, user_id)
@@ -211,15 +213,15 @@ def admin_usun_instruktora(user_id):
             abort(404)
         db.session.delete(instr)
         db.session.commit()
-        flash("Instruktor usunięty.")
-    return redirect(url_for("admin.admin_instruktorzy"))
+        flash("Użytkownik usunięty.")
+    return redirect(url_for("admin.admin_uzytkownicy"))
 
 
-@admin_bp.route("/instruktorzy/<int:user_id>/promote", methods=["POST"])
+@admin_bp.route("/uzytkownicy/<int:user_id>/promote", methods=["POST"])
 @login_required
 @admin_required
-def admin_promote_instruktora(user_id):
-    """Grant admin role to the selected instructor."""
+def admin_promote_uzytkownika(user_id):
+    """Grant admin role to the selected user."""
     form = PromoteForm()
     if form.validate_on_submit():
         instr = db.session.get(User, user_id)
@@ -227,25 +229,25 @@ def admin_promote_instruktora(user_id):
             abort(404)
         instr.role = Roles.ADMIN
         db.session.commit()
-        flash("Instruktor ma teraz uprawnienia admina.")
-    return redirect(url_for("admin.admin_instruktorzy"))
+        flash("Użytkownik ma teraz uprawnienia admina.")
+    return redirect(url_for("admin.admin_uzytkownicy"))
 
 
-@admin_bp.route("/instruktorzy/<int:user_id>/confirm", methods=["GET", "POST"])
+@admin_bp.route("/uzytkownicy/<int:user_id>/confirm", methods=["GET", "POST"])
 @login_required
 @admin_required
-def admin_confirm_instruktora(user_id):
-    """Confirm an instructor account registration."""
+def admin_confirm_uzytkownika(user_id):
+    """Confirm a user account registration."""
     if request.method == "GET":
         token = request.args.get("token")
         user = User.verify_confirm_token(token)
         if user and user.id == user_id:
             user.confirmed = True
             db.session.commit()
-            flash("Instruktor został potwierdzony.")
+            flash("Użytkownik został potwierdzony.")
         else:
             flash("Nieprawidłowy token potwierdzenia.")
-        return redirect(url_for("admin.admin_instruktorzy"))
+        return redirect(url_for("admin.admin_uzytkownicy"))
 
     form = ConfirmForm()
     if form.validate_on_submit():
@@ -254,8 +256,8 @@ def admin_confirm_instruktora(user_id):
             abort(404)
         instr.confirmed = True
         db.session.commit()
-        flash("Instruktor został potwierdzony.")
-    return redirect(url_for("admin.admin_instruktorzy"))
+        flash("Użytkownik został potwierdzony.")
+    return redirect(url_for("admin.admin_uzytkownicy"))
 
 
 @admin_bp.route("/ustawienia", methods=["GET", "POST"])

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -81,7 +81,7 @@ def register():
         if admin_email:
             token = user.get_confirm_token()
             confirm_url = url_for(
-                "admin.admin_confirm_instruktora",
+                "admin.admin_confirm_uzytkownika",
                 user_id=user.id,
                 token=token,
                 _external=True,

--- a/app/templates/_nav_macros.html
+++ b/app/templates/_nav_macros.html
@@ -12,11 +12,11 @@
     <a class="nav-link{% if request.endpoint == 'sessions.lista_beneficjentow' %} active{% endif %}" href="{{ url_for('sessions.lista_beneficjentow') }}"{% if request.endpoint == 'sessions.lista_beneficjentow' %} aria-current="page"{% endif %}>Beneficjenci</a>
   </li>
   {% if current_user.is_authenticated and current_user.role.value == 'admin' %}
-  {% set admin_endpoints = ['admin.admin_instruktorzy', 'admin.admin_beneficjenci', 'admin.admin_zajecia', 'admin.admin_ustawienia'] %}
+  {% set admin_endpoints = ['admin.admin_uzytkownicy', 'admin.admin_beneficjenci', 'admin.admin_zajecia', 'admin.admin_ustawienia'] %}
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle{% if request.endpoint in admin_endpoints %} active{% endif %}" href="#" id="{{ admin_id }}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{% if request.endpoint in admin_endpoints %} aria-current="page"{% endif %}>Admin</a>
     <ul class="dropdown-menu" aria-labelledby="{{ admin_id }}">
-      <li><a class="dropdown-item{% if request.endpoint == 'admin.admin_instruktorzy' %} active{% endif %}" href="{{ url_for('admin.admin_instruktorzy') }}"{% if request.endpoint == 'admin.admin_instruktorzy' %} aria-current="page"{% endif %}>Instruktorzy</a></li>
+      <li><a class="dropdown-item{% if request.endpoint == 'admin.admin_uzytkownicy' %} active{% endif %}" href="{{ url_for('admin.admin_uzytkownicy') }}"{% if request.endpoint == 'admin.admin_uzytkownicy' %} aria-current="page"{% endif %}>Użytkownicy</a></li>
       <li><a class="dropdown-item{% if request.endpoint == 'admin.admin_beneficjenci' %} active{% endif %}" href="{{ url_for('admin.admin_beneficjenci') }}"{% if request.endpoint == 'admin.admin_beneficjenci' %} aria-current="page"{% endif %}>Beneficjenci</a></li>
       <li><a class="dropdown-item{% if request.endpoint == 'admin.admin_zajecia' %} active{% endif %}" href="{{ url_for('admin.admin_zajecia') }}"{% if request.endpoint == 'admin.admin_zajecia' %} aria-current="page"{% endif %}>Zajęcia</a></li>
       <li><a class="dropdown-item{% if request.endpoint == 'admin.admin_ustawienia' %} active{% endif %}" href="{{ url_for('admin.admin_ustawienia') }}"{% if request.endpoint == 'admin.admin_ustawienia' %} aria-current="page"{% endif %}>Ustawienia</a></li>

--- a/app/templates/admin/users_list.html
+++ b/app/templates/admin/users_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Instruktorzy{% endblock %}
+{% block title %}Użytkownicy{% endblock %}
 {% block content %}
 <h2>Instruktorzy</h2>
 <div class="table-responsive">
@@ -17,17 +17,17 @@
       <td>{{ u.full_name }}</td>
       <td>{{ u.email }}</td>
       <td>
-        <a href="{{ url_for('admin.admin_edytuj_instruktora', user_id=u.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj" data-bs-toggle="tooltip" title="Edytuj">
+        <a href="{{ url_for('admin.admin_edytuj_uzytkownika', user_id=u.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj" data-bs-toggle="tooltip" title="Edytuj">
           <i class="bi bi-pencil"></i>
         </a>
-        <form method="post" action="{{ url_for('admin.admin_usun_instruktora', user_id=u.id) }}" style="display:inline;">
+        <form method="post" action="{{ url_for('admin.admin_usun_uzytkownika', user_id=u.id) }}" style="display:inline;">
           {{ delete_form.csrf_token }}
           <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń" data-bs-toggle="tooltip" title="Usuń">
             <i class="bi bi-trash"></i>
           </button>
         </form>
         {% if not u.confirmed %}
-        <form method="post" action="{{ url_for('admin.admin_confirm_instruktora', user_id=u.id) }}" style="display:inline;">
+        <form method="post" action="{{ url_for('admin.admin_confirm_uzytkownika', user_id=u.id) }}" style="display:inline;">
           {{ confirm_form.csrf_token }}
           <button type="submit" class="btn btn-sm btn-success" data-bs-toggle="tooltip" title="Potwierdź rejestrację">Potwierdź rejestrację</button>
         </form>
@@ -47,7 +47,7 @@
                 Czy na pewno chcesz nadać uprawnienia administratora użytkownikowi <strong>{{ u.full_name }}</strong>?
               </div>
               <div class="modal-footer">
-                <form method="post" action="{{ url_for('admin.admin_promote_instruktora', user_id=u.id) }}">
+                <form method="post" action="{{ url_for('admin.admin_promote_uzytkownika', user_id=u.id) }}">
                   {{ promote_form.csrf_token }}
                   <button type="submit" class="btn btn-warning">Nadaj admina</button>
                 </form>
@@ -65,6 +65,41 @@
   </tbody>
 </table>
 </div>
+
+<h2>Administratorzy</h2>
+<div class="table-responsive">
+<table class="table mx-auto text-start">
+  <thead>
+    <tr>
+      <th>Imię i nazwisko</th>
+      <th>Email</th>
+      <th>Akcje</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in admins %}
+    <tr>
+      <td>{{ u.full_name }}</td>
+      <td>{{ u.email }}</td>
+      <td>
+        <a href="{{ url_for('admin.admin_edytuj_uzytkownika', user_id=u.id) }}" class="btn btn-sm btn-primary" aria-label="Edytuj" data-bs-toggle="tooltip" title="Edytuj">
+          <i class="bi bi-pencil"></i>
+        </a>
+        <form method="post" action="{{ url_for('admin.admin_usun_uzytkownika', user_id=u.id) }}" style="display:inline;">
+          {{ delete_form.csrf_token }}
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Na pewno chcesz usunąć?');" aria-label="Usuń" data-bs-toggle="tooltip" title="Usuń">
+            <i class="bi bi-trash"></i>
+          </button>
+        </form>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">Brak administratorów.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+
 <script>
   var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
   tooltipTriggerList.forEach(function (tooltipTriggerEl) {
@@ -72,3 +107,4 @@
   });
 </script>
 {% endblock %}
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -198,8 +198,8 @@ def test_register_sends_confirmation_email(monkeypatch, client, app):
     with app.app_context():
         user = User.query.filter_by(full_name='jan').first()
         assert user is not None
-        assert f'/admin/instruktorzy/{user.id}/confirm' in msg.body
-        assert f'/admin/instruktorzy/{user.id}/confirm' in msg.html
+        assert f'/admin/uzytkownicy/{user.id}/confirm' in msg.body
+        assert f'/admin/uzytkownicy/{user.id}/confirm' in msg.html
         assert '<a ' in msg.html and 'style=' in msg.html
 
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -49,7 +49,7 @@ def login(client, username):
 
 
 def test_admin_access(app):
-    """Admin should be able to view all beneficiaries and instructors."""
+    """Admin should be able to view all beneficiaries and users."""
     admin_id, inst1_id, inst2_id = create_users(app)
     client = app.test_client()
     login(client, 'admin')
@@ -58,9 +58,11 @@ def test_admin_access(app):
     text = resp.get_data(as_text=True)
     assert 'Ben1' in text and 'Ben2' in text
 
-    resp = client.get('/admin/instruktorzy')
+    resp = client.get('/admin/uzytkownicy')
     assert resp.status_code == 200
-    assert 'inst1' in resp.get_data(as_text=True)
+    text = resp.get_data(as_text=True)
+    assert 'inst1' in text
+    assert 'Instruktorzy' in text and 'Administratorzy' in text
 
 
 def test_instructor_cannot_access_admin(app):
@@ -89,7 +91,7 @@ def test_promote_instructor(app):
     client = app.test_client()
     login(client, 'admin')
     resp = client.post(
-        f'/admin/instruktorzy/{inst1_id}/promote',
+        f'/admin/uzytkownicy/{inst1_id}/promote',
         data={'submit': '1'},
         follow_redirects=True,
     )
@@ -99,7 +101,7 @@ def test_promote_instructor(app):
         assert user.role == Roles.ADMIN
     # Instructor should now have admin rights
     login(client, 'inst1')
-    resp = client.get('/admin/instruktorzy')
+    resp = client.get('/admin/uzytkownicy')
     assert resp.status_code == 200
 
 
@@ -124,11 +126,11 @@ def test_confirm_instructor(app):
 
     login(client, 'admin')
     # Page should show confirmation button for the new user
-    resp = client.get('/admin/instruktorzy')
+    resp = client.get('/admin/uzytkownicy')
     assert 'Potwierdź rejestrację' in resp.get_data(as_text=True)
 
     resp = client.post(
-        f'/admin/instruktorzy/{new_id}/confirm',
+        f'/admin/uzytkownicy/{new_id}/confirm',
         data={'submit': '1'},
         follow_redirects=True,
     )


### PR DESCRIPTION
## Zmiany
- Dodano widok `/admin/uzytkownicy` z obsługą listy instruktorów i administratorów oraz operacjami edycji, usuwania, promowania i potwierdzania kont.
- Wprowadzono nowy szablon `users_list.html` z dwiema tabelami: Instruktorzy i Administratorzy.
- Zaktualizowano menu nawigacyjne, aby wskazywało nowy widok użytkowników.
- Zmieniono generowanie linku potwierdzającego w procesie rejestracji.
- Uaktualniono testy do pracy z nową ścieżką.

## Testy
- `pytest tests/test_roles.py tests/test_auth.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896889f3e7c832a81ae7633e5fda1d1