### PR TITLE
Add warning logs for missing resources

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 """Flask application factory and extension initialization."""
 
 import os
+import logging
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
@@ -36,6 +37,11 @@ def create_app(test_config=None):
     env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
     load_dotenv(env_path)
     app = Flask(__name__)
+    if not app.logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        app.logger.addHandler(handler)
+    app.logger.setLevel(logging.INFO)
     # Flask loads configuration from environment variables such as `FLASK_ENV`.
     secret_key = None
     if test_config is not None:

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -82,6 +82,9 @@ def admin_edytuj_beneficjenta(beneficjent_id):
     """Admin view for editing any beneficiary."""
     benef = db.session.get(Beneficjent, beneficjent_id)
     if benef is None:
+        current_app.logger.warning(
+            "admin_edytuj_beneficjenta: beneficjent %s not found", beneficjent_id
+        )
         abort(404)
     form = BeneficjentForm(obj=benef)
     if form.validate_on_submit():
@@ -104,6 +107,9 @@ def admin_usun_beneficjenta(beneficjent_id):
     if form.validate_on_submit():
         benef = db.session.get(Beneficjent, beneficjent_id)
         if benef is None:
+            current_app.logger.warning(
+                "admin_usun_beneficjenta: beneficjent %s not found", beneficjent_id
+            )
             abort(404)
         db.session.delete(benef)
         db.session.commit()
@@ -134,6 +140,9 @@ def admin_edytuj_zajecia(zajecia_id):
     """Admin view for editing any session."""
     zajecia = db.session.get(Zajecia, zajecia_id)
     if zajecia is None:
+        current_app.logger.warning(
+            "admin_edytuj_zajecia: zajecia %s not found", zajecia_id
+        )
         abort(404)
     form = ZajeciaForm(obj=zajecia)
     form.beneficjenci.choices = [
@@ -167,6 +176,9 @@ def admin_usun_zajecia(zajecia_id):
     if form.validate_on_submit():
         zajecia = db.session.get(Zajecia, zajecia_id)
         if zajecia is None:
+            current_app.logger.warning(
+                "admin_usun_zajecia: zajecia %s not found", zajecia_id
+            )
             abort(404)
         db.session.delete(zajecia)
         db.session.commit()
@@ -204,6 +216,9 @@ def admin_edytuj_uzytkownika(user_id):
     """Admin view for editing a user account."""
     instr = db.session.get(User, user_id)
     if instr is None:
+        current_app.logger.warning(
+            "admin_edytuj_uzytkownika: user %s not found", user_id
+        )
         abort(404)
     if instr.role == Roles.ADMIN and current_user.role != Roles.SUPERADMIN:
         abort(403)
@@ -228,6 +243,9 @@ def admin_usun_uzytkownika(user_id):
     if form.validate_on_submit():
         instr = db.session.get(User, user_id)
         if instr is None:
+            current_app.logger.warning(
+                "admin_usun_uzytkownika: user %s not found", user_id
+            )
             abort(404)
         if instr.role == Roles.ADMIN and current_user.role != Roles.SUPERADMIN:
             abort(403)
@@ -246,6 +264,9 @@ def admin_promote_uzytkownika(user_id):
     if form.validate_on_submit():
         instr = db.session.get(User, user_id)
         if instr is None:
+            current_app.logger.warning(
+                "admin_promote_uzytkownika: user %s not found", user_id
+            )
             abort(404)
         instr.role = Roles.ADMIN
         db.session.commit()
@@ -262,8 +283,14 @@ def admin_demote_admin(user_id):
     if form.validate_on_submit():
         user = db.session.get(User, user_id)
         if user is None:
+            current_app.logger.warning(
+                "admin_demote_admin: user %s not found", user_id
+            )
             abort(404)
         if user.role != Roles.ADMIN:
+            current_app.logger.warning(
+                "admin_demote_admin: user %s is not admin", user_id
+            )
             abort(404)
         user.role = Roles.INSTRUCTOR
         db.session.commit()
@@ -291,6 +318,9 @@ def admin_confirm_uzytkownika(user_id):
     if form.validate_on_submit():
         instr = db.session.get(User, user_id)
         if instr is None:
+            current_app.logger.warning(
+                "admin_confirm_uzytkownika: user %s not found", user_id
+            )
             abort(404)
         instr.confirmed = True
         db.session.commit()

--- a/app/sessions/routes.py
+++ b/app/sessions/routes.py
@@ -139,6 +139,7 @@ def pobierz_docx(zajecia_id):
     """Generate and return a DOCX report for the given session."""
     zajecia = db.session.get(Zajecia, zajecia_id)
     if zajecia is None:
+        current_app.logger.warning("pobierz_docx: zajecia %s not found", zajecia_id)
         abort(404)
     if zajecia.user_id != current_user.id:
         flash("Brak dostępu do tych zajęć.")
@@ -167,6 +168,7 @@ def wyslij_docx(zajecia_id):
     """Regenerate a DOCX report and email it to the configured recipient."""
     zajecia = db.session.get(Zajecia, zajecia_id)
     if zajecia is None:
+        current_app.logger.warning("wyslij_docx: zajecia %s not found", zajecia_id)
         abort(404)
     if zajecia.user_id != current_user.id:
         flash("Brak dostępu do tych zajęć.")
@@ -216,6 +218,7 @@ def resend_email(email_id):
     """Regenerate attachment and resend the email."""
     sent_email = db.session.get(SentEmail, email_id)
     if sent_email is None:
+        current_app.logger.warning("resend_email: email %s not found", email_id)
         abort(404)
     if not sent_email.zajecia or sent_email.zajecia.user_id != current_user.id:
         flash("Brak dostępu do tej wiadomości.")
@@ -268,6 +271,7 @@ def edytuj_zajecia(zajecia_id):
     """Edit an existing session belonging to the current user."""
     zajecia = db.session.get(Zajecia, zajecia_id)
     if zajecia is None:
+        current_app.logger.warning("edytuj_zajecia: zajecia %s not found", zajecia_id)
         abort(404)
     if zajecia.user_id != current_user.id:
         flash("Brak dostępu do tych zajęć.")
@@ -305,6 +309,7 @@ def usun_zajecia(zajecia_id):
     if form.validate_on_submit():
         zajecia = db.session.get(Zajecia, zajecia_id)
         if zajecia is None:
+            current_app.logger.warning("usun_zajecia: zajecia %s not found", zajecia_id)
             abort(404)
         if zajecia.user_id != current_user.id:
             flash("Brak dostępu do tych zajęć.")
@@ -409,6 +414,9 @@ def edytuj_beneficjenta(beneficjent_id):
     """Edit an existing beneficiary belonging to the user."""
     benef = db.session.get(Beneficjent, beneficjent_id)
     if benef is None:
+        current_app.logger.warning(
+            "edytuj_beneficjenta: beneficjent %s not found", beneficjent_id
+        )
         abort(404)
     if benef.user_id != current_user.id:
         flash("Brak dostępu do tego beneficjenta.")
@@ -433,6 +441,9 @@ def usun_beneficjenta(beneficjent_id):
     if form.validate_on_submit():
         benef = db.session.get(Beneficjent, beneficjent_id)
         if benef is None:
+            current_app.logger.warning(
+                "usun_beneficjenta: beneficjent %s not found", beneficjent_id
+            )
             abort(404)
         if benef.user_id != current_user.id:
             flash("Brak dostępu do tego beneficjenta.")


### PR DESCRIPTION
## Summary
- log warnings before each abort(404) in session and admin routes
- configure a basic StreamHandler for the application logger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973790e418832a90a412a098368ee7