### PR TITLE
Return 403 instead of 404 when demoting non-admin users

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -291,7 +291,7 @@ def admin_demote_admin(user_id):
             current_app.logger.warning(
                 "admin_demote_admin: user %s is not admin", user_id
             )
-            abort(404)
+            abort(403)
         user.role = Roles.INSTRUCTOR
         db.session.commit()
         flash("Użytkownik został zdegradowany.")

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -182,3 +182,19 @@ def test_only_superadmin_can_demote_admin(app):
     with app.app_context():
         user = db.session.get(User, admin_id)
         assert user.role == Roles.INSTRUCTOR
+
+
+def test_superadmin_cannot_demote_instructor(app):
+    """Superadmin should not be able to demote a user who is not an admin."""
+    superadmin_id, admin_id, inst1_id, inst2_id = create_users(app)
+    client = app.test_client()
+
+    login(client, 'superadmin')
+    resp = client.post(
+        f'/admin/uzytkownicy/{inst1_id}/demote',
+        data={'submit': '1'},
+    )
+    assert resp.status_code == 403
+    with app.app_context():
+        user = db.session.get(User, inst1_id)
+        assert user.role == Roles.INSTRUCTOR


### PR DESCRIPTION
## Summary
- return HTTP 403 when attempting to demote a user who isn't an admin
- test that demoting a non-admin user is forbidden

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68975497505c832a80977e79706890cc