### PR TITLE
Use timezone-aware datetimes and silence flask-login warning

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import io
-from datetime import datetime
+from datetime import datetime, UTC
 
 from flask import flash, current_app
 from flask_mail import Message
@@ -58,7 +58,7 @@ def send_email(subject, recipients, body, attachments=None, html_body=None):
     sent_at = None
     try:
         mail.send(msg)
-        sent_at = datetime.utcnow()
+        sent_at = datetime.now(UTC)
         status = "sent"
     except SMTPException as exc:
         current_app.logger.error("Failed to send email: %s", exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,20 @@
 import os
 import sys
 import pytest
+from datetime import datetime, UTC
+import flask_login.login_manager as login_manager
 from app import create_app, db
 from app.models import User
+
+
+# Use timezone-aware datetimes in flask-login to avoid deprecation warnings
+class _AwareDatetime(datetime):
+    @classmethod
+    def utcnow(cls):  # pragma: no cover - simple patch
+        return datetime.now(UTC)
+
+
+login_manager.datetime = _AwareDatetime
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Replace deprecated `datetime.utcnow()` with timezone-aware `datetime.now(UTC)` in email sending
- Patch Flask-Login's `datetime.utcnow` usage in tests to avoid deprecation warnings

## Testing
- `pytest -W default`

------
https://chatgpt.com/codex/tasks/task_e_6897628bf50c832aa070c74dec463f11