### PR TITLE
Adjust mobile menu width

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -11,6 +11,10 @@
     opacity: 0.85;
 }
 
+#mobileMenu {
+    width: 80vw;
+}
+
 /* Sticky header for tables */
 .table thead th {
     position: sticky;
@@ -49,4 +53,8 @@ body.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
 
 body.dark-mode .table-hover > tbody > tr:hover {
     background-color: #343a40 !important;
+}
+
+body.dark-mode #mobileMenu {
+    width: 80vw;
 }


### PR DESCRIPTION
## Summary
- Define a width of 80vw for the mobile menu
- Mirror the mobile menu width rule under dark mode styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897b8674c30832abddf22dee14591fd