### PR TITLE
style: improve mobile menu links

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -15,6 +15,16 @@
     width: 80vw;
 }
 
+#mobileMenu .nav-link {
+    font-size: 1.2rem;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid #dee2e6;
+}
+
+#mobileMenu .navbar-nav {
+    gap: 0.5rem;
+}
+
 /* Sticky header for tables */
 .table thead th {
     position: sticky;


### PR DESCRIPTION
## Summary
- expand mobile menu links with larger font, padding, and subtle borders
- add vertical gap to mobile menu navigation list for spacing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897bc452c30832a9bd85bde543237d9