### PR TITLE
Refactor mobile menu layout and logout handling

### DIFF
--- a/app/templates/_nav_macros.html
+++ b/app/templates/_nav_macros.html
@@ -25,13 +25,19 @@
   {% endif %}
 {% endmacro %}
 
-{% macro render_user_items() %}
+{% macro render_settings_item() %}
   {% if current_user.is_authenticated %}
   <li class="nav-item">
     <a class="nav-link{% if request.endpoint == 'auth.user_settings' %} active{% endif %}" href="{{ url_for('auth.user_settings') }}"{% if request.endpoint == 'auth.user_settings' %} aria-current="page"{% endif %}>Ustawienia</a>
   </li>
-  <li class="nav-item">
-    <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('auth.logout') }}">Wyloguj</a>
-  </li>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_user_items() %}
+  {% if current_user.is_authenticated %}
+    {{ render_settings_item() }}
+    <li class="nav-item">
+      <a class="btn btn-danger btn-sm logout-btn" href="{{ url_for('auth.logout') }}">Wyloguj</a>
+    </li>
   {% endif %}
 {% endmacro %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body class="bg-light text-dark pb-5">
-  {% from '_nav_macros.html' import render_nav_items, render_user_items with context %}
+  {% from '_nav_macros.html' import render_nav_items, render_user_items, render_settings_item with context %}
   <header class="bg-white border-bottom py-2 mb-3">
     <div class="container d-flex align-items-center">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo" class="me-2" style="height: 40px;">
@@ -47,11 +47,14 @@
       <h5 class="offcanvas-title" id="mobileMenuLabel">Menu</h5>
       <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body">
+    <div class="offcanvas-body d-flex flex-column">
       <ul class="navbar-nav flex-grow-1 pe-3 justify-content-center">
         {{ render_nav_items('adminMenuMobile') }}
-        {{ render_user_items() }}
+        {{ render_settings_item() }}
       </ul>
+      <a class="btn btn-danger w-75 mx-auto mt-auto" href="{{ url_for('auth.logout') }}">
+        Wyloguj
+      </a>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- Refactor mobile offcanvas menu to use flex layout and move logout button outside nav list
- Extract a standalone settings link macro and use it for user items

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c359835c832abb9c3c7b595b8cd5