### PR TITLE
Focus first link when offcanvas opens and style link focus

### DIFF
--- a/app/static/dark_mode.js
+++ b/app/static/dark_mode.js
@@ -24,4 +24,13 @@ document.addEventListener('DOMContentLoaded', function () {
     applyDarkMode(newTheme);
     localStorage.setItem('theme', newTheme);
   });
+  const mobileMenu = document.getElementById('mobileMenu');
+  if (mobileMenu) {
+    mobileMenu.addEventListener('shown.bs.offcanvas', function () {
+      const firstLink = mobileMenu.querySelector('a');
+      if (firstLink) {
+        firstLink.focus();
+      }
+    });
+  }
 });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -10,6 +10,11 @@
 .logout-btn:hover {
     opacity: 0.85;
 }
+a:focus {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+}
+
 
 #mobileMenu {
     width: 80vw;


### PR DESCRIPTION
## Summary
- ensure the offcanvas menu focuses its first link when opened
- add a focus outline for links so the active element is visible

## Testing
- `pytest`
- `flake8` *(fails: line too long, blank line, unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6897db73fc8c832aaf99ef6f851909f9