### PR TITLE
Adjust mobile menu link spacing

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -21,13 +21,13 @@ a:focus {
 }
 
 #mobileMenu .nav-link {
-    font-size: 1.2rem;
-    padding: 1rem 1.5rem;
+    font-size: 1.4rem;
+    padding: 1.25rem 2rem;
     border-bottom: 1px solid #dee2e6;
 }
 
 #mobileMenu .navbar-nav {
-    gap: 0.5rem;
+    gap: 1rem;
 }
 
 /* Sticky header for tables */


### PR DESCRIPTION
## Summary
- enlarge font size and padding for mobile menu links
- widen navbar gap on mobile menu for better spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988f589234832a98c8bed0dffd8084